### PR TITLE
adds registry-free butler support

### DIFF
--- a/python/lsst/obs/decam/decamMapper.py
+++ b/python/lsst/obs/decam/decamMapper.py
@@ -33,6 +33,16 @@ np.seterr(divide="ignore")
 class DecamMapper(CameraMapper):
     packageName = 'obs_decam'
 
+    detectorNames = {1:'S29', 2:'S30', 3:'S31', 4:'S25', 5:'S26', 6:'S27', 7:'S28', 8:'S20', 9:'S21',
+                          10:'S22', 11:'S23', 12:'S24', 13:'S14', 14:'S15', 15:'S16', 16:'S17', 17:'S18',
+                          18:'S19', 19:'S8', 20:'S9', 21:'S10', 22:'S11', 23:'S12', 24:'S13', 25:'S1',
+                          26:'S2', 27:'S3', 28:'S4', 29:'S5', 30:'S6', 32:'N1', 33:'N2', 34:'N3', 35:'N4',
+                          36:'N5', 37:'N6', 38:'N7', 39:'N8', 40:'N9', 41:'N10', 42:'N11', 43:'N12', 44:'N13',
+                          45:'N14', 46:'N15', 47:'N16', 48:'N17', 49:'N18', 50:'N19', 51:'N20', 52:'N21',
+                          53:'N22', 54:'N23', 55:'N24', 56:'N25', 57:'N26', 58:'N27', 59:'N28', 60:'N29',
+                          62:'N31'}
+
+
     def __init__(self, inputPolicy=None, **kwargs):
         policyFile = pexPolicy.DefaultPolicyFile(self.packageName, "DecamMapper.paf", "policy")
         policy = pexPolicy.Policy(policyFile)
@@ -61,13 +71,10 @@ class DecamMapper(CameraMapper):
                                      DecamMapper._nbit_filter)
 
     def _extractDetectorName(self, dataId):
-        nameTuple = self.registry.executeQuery(['side','ccd'], ['raw',], [('ccdnum','?'), ('visit','?')],
-                                               None, (dataId['ccdnum'], dataId['visit']))
-        if len(nameTuple) > 1:
-            raise RuntimeError("More than one name returned")
-        if len(nameTuple) == 0:
+        try:
+            return DecamMapper.detectorNames[dataId['ccdnum']]
+        except KeyError:
             raise RuntimeError("No name found for dataId: %s"%(dataId))
-        return "%s%i" % (nameTuple[0][0], nameTuple[0][1])
 
     def bypass_ccdExposureId(self, datasetType, pythonType, location, dataId):
         return self._computeCcdExposureId(dataId)


### PR DESCRIPTION
regarding the steps in the readme.md for this package,
now processCcdDecam.py can be run without the registry.sqlite file.
HOWEVER for this script, the data must still be imported (step 3,
ingestImagesDecam.py) because this creates files (aliases, actually)
that conform to the template in the policy file. The registry free
butler depends on this correlation between file names and template.