### PR TITLE
DM-4669 Removed the obs_decam config override for calibrate.initialPsf.fwhm

### DIFF
--- a/config/processCcdDecam.py
+++ b/config/processCcdDecam.py
@@ -1,2 +1,1 @@
-config.calibrate.initialPsf.fwhm=2.0
 config.calibrate.repair.cosmicray.nCrPixelMax=100000


### PR DESCRIPTION
obs_decam config override has calibrate.initialPsf.fwhm=2.0 arcsec.
This is far too large. We decided on the RFD discussion on "initial
PSF FWHM" to remove this config override and use the default value
in the calibrate task. The idea is to tweak the calibrate default
value to make it work pretty much for all data.
