### PR TITLE
Strip WCS keys from metadata of instcals.

### DIFF
--- a/tests/testGetInstcal.py
+++ b/tests/testGetInstcal.py
@@ -1,0 +1,107 @@
+from __future__ import print_function
+#
+# LSST Data Management System
+# Copyright 2016 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+import math
+import os
+import warnings
+import unittest
+
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+
+import lsst.pex.exceptions as pexExcept
+import lsst.daf.persistence as dafPersist
+
+from testGetRaw import visit229388_info
+
+
+class GetInstcalTestCase(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        try:
+            datadir = getPackageDir("testdata_decam")
+        except pexExcept.NotFoundError:
+            message = "testdata_decam not setup. Skipping."
+            warnings.warn(message)
+            raise unittest.SkipTest(message)
+
+        self.repoPath = os.path.join(datadir, "cpData")
+        self.butler = dafPersist.Butler(root=self.repoPath)
+        self.size = (2046, 4094)
+        self.dataId = {'visit': 229388, 'ccdnum': 1}
+        self.filter = "z"
+
+    def tearDown(self):
+        del self.butler
+
+    def testInstcal(self):
+        """Test retrieval of community pipeline-processed image"""
+        exp = self.butler.get("instcal", self.dataId, immediate=True)
+
+        self.assertEqual(exp.getWidth(), self.size[0])
+        self.assertEqual(exp.getHeight(), self.size[1])
+        self.assertEqual(exp.getDetector().getId(), self.dataId["ccdnum"])
+        self.assertEqual(exp.getFilter().getFilterProperty().getName(), self.filter)
+        self.assertTrue(exp.hasWcs())
+
+        visitInfo = exp.getInfo().getVisitInfo()
+        self.assertEqual(visitInfo.getDate(), visit229388_info['dateAvg'])
+        self.assertEqual(visitInfo.getExposureTime(), visit229388_info['exposureTime'])
+        self.assertEqual(visitInfo.getDarkTime(), visit229388_info['darkTime'])
+        visitInfo = exp.getInfo().getVisitInfo()
+        self.assertEqual(visitInfo.getDate(), visit229388_info['dateAvg'])
+        self.assertCoordsNearlyEqual(visitInfo.getBoresightRaDec(), visit229388_info['boresightRaDec'])
+        self.assertCoordsNearlyEqual(visitInfo.getBoresightAzAlt(), visit229388_info['boresightAzAlt'])
+        self.assertAlmostEqual(visitInfo.getBoresightAirmass(), visit229388_info['boresightAirmass'])
+        self.assertTrue(math.isnan(visitInfo.getBoresightRotAngle().asDegrees()))
+        self.assertEqual(visitInfo.getRotType(), visit229388_info['rotType'])
+        observatory = visitInfo.getObservatory()
+        self.assertAnglesNearlyEqual(observatory.getLongitude(), visit229388_info['obs_longitude'])
+        self.assertAnglesNearlyEqual(observatory.getLatitude(), visit229388_info['obs_latitude'])
+        self.assertAlmostEqual(observatory.getElevation(), visit229388_info['obs_elevation'])
+        weather = visitInfo.getWeather()
+        self.assertAlmostEqual(weather.getAirTemperature(), visit229388_info['weath_airTemperature'])
+        self.assertAlmostEqual(weather.getAirPressure(), visit229388_info['weath_airPressure'])
+        self.assertAlmostEqual(weather.getHumidity(), visit229388_info['weath_humidity'])
+
+        # Example of metadata which should *not* have been copied from zeroth extension.
+        self.assertNotIn("PROPOSER", exp.getMetadata().paramNames())
+
+        # Metadata should not contain WCS or TPV headers.
+        # This is not an exhaustive list.
+        wcs_keywords = ("PV1_1", "PV2_1", "CRPIX1", "CD2_1", "CRVAL2", "LTV1")
+        for keyword in wcs_keywords:
+            self.assertNotIn(keyword, exp.getMetadata().paramNames())
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testGetRaw.py
+++ b/tests/testGetRaw.py
@@ -39,6 +39,25 @@ from lsst.afw.coord import IcrsCoord, Coord
 from lsst.afw.geom import degrees
 
 
+# Desired VisitInfo values for visit 229388, shared between testGetRaw.py and
+# testGetInstcal.py
+visit229388_info = {
+    "dateAvg": DateTime("2013-09-01T06:05:10.753848", DateTime.TAI),
+    "exposureTime": 200.0,
+    "darkTime": 201.15662,
+    "boresightRaDec": IcrsCoord('02:51:16.790', '-00:00:05.699'),
+    "boresightAzAlt": Coord(61.24*degrees, (90-50.46)*degrees),
+    "boresightAirmass": 1.57,
+    "boresightRotAngle": float("nan")*degrees,
+    "rotType": RotType_UNKNOWN,
+    "obs_longitude": 70.81489000000001*degrees,
+    "obs_latitude": -30.16606*degrees,
+    "obs_elevation": 2215.0,
+    "weath_airTemperature": 11.9,
+    "weath_airPressure": MakeRawVisitInfo.pascalFromMmHg(779.0),
+    "weath_humidity": 23.0}
+
+
 class GetRawTestCase(lsst.utils.tests.TestCase):
     """Testing butler raw image retrieval"""
 
@@ -56,20 +75,6 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         self.size = (2160, 4146)
         self.dataId = {'visit': 229388, 'ccdnum': 1}
         self.filter = "z"
-        self.dateAvg = DateTime("2013-09-01T06:05:10.753848", DateTime.TAI)
-        self.exposureTime = 200.0
-        self.darkTime = 201.15662
-        self.boresightRaDec = IcrsCoord('02:51:16.790', '-00:00:05.699')
-        self.boresightAzAlt = Coord(61.24*degrees, (90-50.46)*degrees)
-        self.boresightAirmass = 1.57
-        self.boresightRotAngle = float("nan")*degrees
-        self.rotType = RotType_UNKNOWN
-        self.obs_longitude = 70.81489000000001*degrees
-        self.obs_latitude = -30.16606*degrees
-        self.obs_elevation = 2215.0
-        self.weath_airTemperature = 11.9
-        self.weath_airPressure = MakeRawVisitInfo.pascalFromMmHg(779.0)
-        self.weath_humidity = 23.0
 
     def tearDown(self):
         del self.butler
@@ -95,24 +100,24 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
 
         # Metadata which should have been copied from zeroth extension.
         visitInfo = exp.getInfo().getVisitInfo()
-        self.assertEqual(visitInfo.getDate(), self.dateAvg)
-        self.assertEqual(visitInfo.getExposureTime(), self.exposureTime)
-        self.assertEqual(visitInfo.getDarkTime(), self.darkTime)
+        self.assertEqual(visitInfo.getDate(), visit229388_info['dateAvg'])
+        self.assertEqual(visitInfo.getExposureTime(), visit229388_info['exposureTime'])
+        self.assertEqual(visitInfo.getDarkTime(), visit229388_info['darkTime'])
         visitInfo = exp.getInfo().getVisitInfo()
-        self.assertEqual(visitInfo.getDate(), self.dateAvg)
-        self.assertCoordsNearlyEqual(visitInfo.getBoresightRaDec(), self.boresightRaDec)
-        self.assertCoordsNearlyEqual(visitInfo.getBoresightAzAlt(), self.boresightAzAlt)
-        self.assertAlmostEqual(visitInfo.getBoresightAirmass(), self.boresightAirmass)
+        self.assertEqual(visitInfo.getDate(), visit229388_info['dateAvg'])
+        self.assertCoordsNearlyEqual(visitInfo.getBoresightRaDec(), visit229388_info['boresightRaDec'])
+        self.assertCoordsNearlyEqual(visitInfo.getBoresightAzAlt(), visit229388_info['boresightAzAlt'])
+        self.assertAlmostEqual(visitInfo.getBoresightAirmass(), visit229388_info['boresightAirmass'])
         self.assertTrue(math.isnan(visitInfo.getBoresightRotAngle().asDegrees()))
-        self.assertEqual(visitInfo.getRotType(), self.rotType)
+        self.assertEqual(visitInfo.getRotType(), visit229388_info['rotType'])
         observatory = visitInfo.getObservatory()
-        self.assertAnglesNearlyEqual(observatory.getLongitude(), self.obs_longitude)
-        self.assertAnglesNearlyEqual(observatory.getLatitude(), self.obs_latitude)
-        self.assertAlmostEqual(observatory.getElevation(), self.obs_elevation)
+        self.assertAnglesNearlyEqual(observatory.getLongitude(), visit229388_info['obs_longitude'])
+        self.assertAnglesNearlyEqual(observatory.getLatitude(), visit229388_info['obs_latitude'])
+        self.assertAlmostEqual(observatory.getElevation(), visit229388_info['obs_elevation'])
         weather = visitInfo.getWeather()
-        self.assertAlmostEqual(weather.getAirTemperature(), self.weath_airTemperature)
-        self.assertAlmostEqual(weather.getAirPressure(), self.weath_airPressure)
-        self.assertAlmostEqual(weather.getHumidity(), self.weath_humidity)
+        self.assertAlmostEqual(weather.getAirTemperature(), visit229388_info['weath_airTemperature'])
+        self.assertAlmostEqual(weather.getAirPressure(), visit229388_info['weath_airPressure'])
+        self.assertAlmostEqual(weather.getHumidity(), visit229388_info['weath_humidity'])
 
         # Example of metadata which should *not* have been copied from zeroth extension.
         self.assertNotIn("PROPOSER", exp.getMetadata().paramNames())


### PR DESCRIPTION
This avoids duplication of conflicting WCS keywords.
