### PR TITLE
Use HDU in instcal templates instead of ccdnum.

### DIFF
--- a/policy/DecamMapper.paf
+++ b/policy/DecamMapper.paf
@@ -36,7 +36,7 @@ exposures: {
         template:    "%(visit)07d/postISR/postISR-%(visit)07d_%(ccdnum)02d.fits"
     }
     instcal: {
-        template:    "%(visit)07d/instcal%(visit)07d.fits.fz[%(ccdnum)d]"
+        template:    "%(visit)07d/instcal%(visit)07d.fits.fz[%(hdu)d]"
         python:      "lsst.afw.image.DecoratedImageF"
         persistable: "DecoratedImageF"
         storage:     "FitsStorage"
@@ -46,7 +46,7 @@ exposures: {
         columns:     "ccdnum"
     }
     dqmask: {
-        template:    "%(visit)07d/dqmask%(visit)07d.fits.fz[%(ccdnum)d]"
+        template:    "%(visit)07d/dqmask%(visit)07d.fits.fz[%(hdu)d]"
         python:      "lsst.afw.image.ImageU"
         persistable: "ImageU"
         storage:     "FitsStorage"
@@ -56,7 +56,7 @@ exposures: {
         columns:     "ccdnum"
     }
     wtmap: {
-        template:    "%(visit)07d/wtmap%(visit)07d.fits.fz[%(ccdnum)d]"
+        template:    "%(visit)07d/wtmap%(visit)07d.fits.fz[%(hdu)d]"
         python:      "lsst.afw.image.ImageF"
         persistable: "ImageF"
         storage:     "FitsStorage"

--- a/python/lsst/obs/decam/decamMapper.py
+++ b/python/lsst/obs/decam/decamMapper.py
@@ -66,9 +66,11 @@ class DecamMapper(CameraMapper):
         afwImageUtils.defineFilter('SOLID', lambdaEff=0, alias=['solid'])
 
         # The data ID key ccdnum is not directly used in the current policy
-        # template of the raw dataset, so is not in its keyDict automatically.
-        # Add it so raw dataset know about the data ID key ccdnum.
-        self.mappings["raw"].keyDict.update({'ccdnum': int})
+        # template of the raw and instcal et al. datasets, so is not in its
+        # keyDict automatically. Add it so the butler know about the data ID key
+        # ccdnum.
+        for datasetType in ("raw", "instcal", "dqmask", "wtmap"):
+            self.mappings[datasetType].keyDict.update({'ccdnum': int})
 
         # The number of bits allocated for fields in object IDs
         # TODO: This needs to be updated; also see Trac #2797

--- a/tests/testGetInstcal.py
+++ b/tests/testGetInstcal.py
@@ -94,6 +94,13 @@ class GetInstcalTestCase(lsst.utils.tests.TestCase):
         for keyword in wcs_keywords:
             self.assertNotIn(keyword, exp.getMetadata().paramNames())
 
+    def testCcdName(self):
+        """Verify that we get the proper CCD for a specified ccdnum."""
+        dataId = {'visit': 229388, 'ccdnum': 62}
+        exp = self.butler.get("instcal", dataId, immediate=True)
+        md = exp.getMetadata()
+        self.assertEqual(md.get("DETPOS"), "N31")
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
Since an HDU's position in an instcal file does not necessarily correspond to
its CCD number, this template had been mislabling CCDs.

Also removes special handling of decam raw files that was required to track the
hdu field. This code was largely a duplication of the pipe_tasks ingest task,
and can be alleviated with the minor changes to that task (also implemented on
this ticket.)