### PR TITLE
DM-9113: the bias ingestion should not care about the filter

### DIFF
--- a/python/lsst/obs/decam/ingestCalibs.py
+++ b/python/lsst/obs/decam/ingestCalibs.py
@@ -87,6 +87,8 @@ class DecamCalibsParseTask(CalibsParseTask):
         @param md (PropertySet) FITS header metadata
         """
         if md.exists("FILTER"):
+            if md.exists("OBSTYPE") and "zero" in md.get("OBSTYPE").strip().lower():
+                return "NONE"
             return CalibsParseTask.translate_filter(self, md)
         elif md.exists("CALIB_ID"):
             return self._translateFromCalibId("filter", md)


### PR DESCRIPTION
Use NONE for CP bias, no matter what FILTER header says, so to get
around wrong validity fix with misleading filter headers in bias.