### PR TITLE
DM-9952: Change our interpretation of FITS HDUs to be 0-indexed

### DIFF
--- a/config/ingestCalibs.py
+++ b/config/ingestCalibs.py
@@ -1,6 +1,6 @@
 from lsst.obs.decam.ingestCalibs import DecamCalibsParseTask
 config.parse.retarget(DecamCalibsParseTask)
-config.parse.hdu = 1
+config.parse.hdu = 0
 
 # N30 is not included becasue it is not functional.
 config.parse.extnames = ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'S8', 'S9', 'S10', 'S11', 'S12', 'S13',


### PR DESCRIPTION
The implementation of DM-9952 unintentionally broke decam defect ingesting, which has a hardwired config expecting the first HDU to be 1. This simple change updates it to expect 0-indexing.