### PR TITLE
obs_decam - modernize Butler API use in testGetId

### DIFF
--- a/tests/getIdRepo/repositoryCfg.yaml
+++ b/tests/getIdRepo/repositoryCfg.yaml
@@ -1,0 +1,7 @@
+!RepositoryCfg_v1
+_mapper: !!python/name:lsst.obs.decam.decamMapper.DecamMapper ''
+_mapperArgs: null
+_parents: []
+_policy: null
+_root: '../'
+dirty: true

--- a/tests/testGetId.py
+++ b/tests/testGetId.py
@@ -21,23 +21,24 @@
 #
 from __future__ import absolute_import, division, print_function
 
+import os
 import unittest
 
 import lsst.utils.tests
 import lsst.daf.persistence as dafPersist
-from lsst.obs.decam import DecamMapper
+
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 class GetIdTestCase(lsst.utils.tests.TestCase):
     """Testing butler exposure id retrieval"""
 
     def setUp(self):
-        self.bf = dafPersist.ButlerFactory(mapper=DecamMapper(root="."))
-        self.butler = self.bf.create()
+        self.butler = dafPersist.Butler(inputs=os.path.join(ROOT, 'getIdRepo'))
 
     def tearDown(self):
         del self.butler
-        del self.bf
 
     def testId(self):
         """Test retrieval of exposure ids"""


### PR DESCRIPTION
This test was failing because of a sequence of
events:

The test was passing into Butler init an
instantiated mapper passed in but not comparing
equal with the mapper loaded by the repository
cfg.

A repositoryCfg.yaml was being created by the old
use of the Butler API (because the old API creates
a read-write output repository), and it was not
geting cleaned up by the test.

When the test runs again on the same computer
where the old repositoryCfg.yaml file exists, the
mapper is reinstantiated as described by the
repositoryCfg file.

The passed-in instantiated mapper and the
reinstantiated mapper do not compare equal,
becuase they do not implement the __eq__ method
and they are not the same instance.

Butler interprets this as the mapper from the cfg
and the passed-in mapper do not match, and it
raises an exception.

The better fix is to not pass an instantiated
mapper to Butler init, instead pass the class
object and let Butler init the mapper.