### PR TITLE
DM-11614: Reset filters before they are defined

### DIFF
--- a/python/lsst/obs/decam/decamMapper.py
+++ b/python/lsst/obs/decam/decamMapper.py
@@ -57,6 +57,7 @@ class DecamMapper(CameraMapper):
 
         super(DecamMapper, self).__init__(policy, os.path.dirname(policyFile), **kwargs)
 
+        afwImageUtils.resetFilters()
         afwImageUtils.defineFilter('u', lambdaEff=350, alias=['u DECam c0006 3500.0 1000.0'])
         afwImageUtils.defineFilter('g', lambdaEff=450, alias=['g DECam SDSS c0001 4720.0 1520.0'])
         afwImageUtils.defineFilter('r', lambdaEff=600, alias=['r DECam SDSS c0002 6415.0 1480.0'])


### PR DESCRIPTION
Without this, the jointcal tests fail (first attempt was in lsst/jointcal#48).