### PR TITLE
DM-13096: Ensure Weather metadata is within valid range.

### DIFF
--- a/python/lsst/obs/decam/makeDecamRawVisitInfo.py
+++ b/python/lsst/obs/decam/makeDecamRawVisitInfo.py
@@ -63,11 +63,12 @@ class MakeDecamRawVisitInfo(MakeRawVisitInfo):
             self.popAngle(md, "OBS-LAT"),
             self.popFloat(md, "OBS-ELEV"),
         )
-        argDict["weather"] = Weather(
-            self.popFloat(md, "OUTTEMP"),
-            self.pascalFromMmHg(self.popFloat(md, "PRESSURE")),
-            self.popFloat(md, "HUMIDITY")
-        )
+        # Default weather is based on typical conditions at an altitude of 2215 meters.
+        temperature = self.defaultMetadata(self.popFloat(md, "OUTTEMP"), 10., minimum=-10., maximum=40.)
+        pressure = self.defaultMetadata(self.pascalFromMmHg(self.popFloat(md, "PRESSURE")), 77161.1,
+                                        minimum=70000., maximum=85000.)
+        humidity = self.defaultMetadata(self.popFloat(md, "HUMIDITY"), 40., minimum=0., maximum=100.)
+        argDict["weather"] = Weather(temperature, pressure, humidity)
         longitude = argDict["observatory"].getLongitude()
         argDict['era'] = self.decamGetEra(md, argDict["boresightRaDec"][0], longitude)
 

--- a/tests/test_getRaw.py
+++ b/tests/test_getRaw.py
@@ -60,7 +60,7 @@ visit229388_info = {
     "obs_latitude": -30.16606*degrees,
     "obs_elevation": 2215.0,
     "weath_airTemperature": 11.9,
-    "weath_airPressure": MakeRawVisitInfo.pascalFromMmHg(779.0),
+    "weath_airPressure": 77161.1,
     "weath_humidity": 23.0}
 
 


### PR DESCRIPTION
Some decam metadata has the pressure set to 1 atmosphere, which is not correct. It needs to be close to correct in order to calculate the right amount of refraction for an observation.