### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/DecamMapper.yaml
+++ b/policy/DecamMapper.yaml
@@ -265,3 +265,5 @@ datasets:
     template: config/dcrCoadd_forced.py
   dcrCoadd_forced_metadata:
     template: dcrCoadd_forced_metadata/%(filter)s/%(tract)d/%(patch)s.boost
+  apPipe_metadata:
+    template: '%(visit)07d/apPipe_metadata/metadata-%(visit)07d_%(ccdnum)02d.boost'


### PR DESCRIPTION
This PR registers a dataset mapping for metadata persisted by `ApPipeTask`. The config dataset is delegated to `obs_base`.