### PR TITLE
DM-13530: Generalize ingestion to non-HiTS data

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -1,0 +1,13 @@
+# Config override for lsst.ap.verify.DatasetIngestTask
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.decam.ingest import DecamIngestTask
+
+decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+
+config.dataIngester.retarget(DecamIngestTask)
+config.dataIngester.load(os.path.join(decamConfigDir, 'ingest.py'))
+config.calibIngester.load(os.path.join(decamConfigDir, 'ingestCalibs.py'))
+config.defectIngester.load(os.path.join(decamConfigDir, 'ingestCalibs.py'))
+


### PR DESCRIPTION
This PR adds an observatory override file for `lsst.ap.verify.DatasetIngestTask` to `obs_decam`.