### PR TITLE
DM-14237: Change DecamIngestTask --filetype default from instcal to raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Documentation of the LSST Science Pipelines is at https://pipelines.lsst.io
 
 3. Import instcal/dqmask/wtmap data into the data repository:
 
-        $ ingestImagesDecam.py /path/to/repo --mode=link instcal/*.fits.fz
+        $ ingestImagesDecam.py /path/to/repo --filetype instcal --mode=link instcal/*.fits.fz
 
 4. Alternatively, import raw and calibration data into the data repository, for example:
 

--- a/python/lsst/obs/decam/ingest.py
+++ b/python/lsst/obs/decam/ingest.py
@@ -41,7 +41,7 @@ class DecamIngestArgumentParser(IngestArgumentParser):
             "\nseparate files each with a unique name but with a common unique identifier"\
             "\nEXPNUM in the FITS header. The 3 files of the same EXPNUM will be aggregated."\
             "\nFor example, the user creates the registry by running"\
-            "\n    ingestImagesDecam.py outputRepository --mode=link instcal/*fits"
+            "\n    ingestImagesDecam.py outputRepository --filetype=instcal --mode=link instcal/*fits"
 
 
 class DecamIngestTask(IngestTask):

--- a/python/lsst/obs/decam/ingest.py
+++ b/python/lsst/obs/decam/ingest.py
@@ -33,7 +33,7 @@ class DecamIngestArgumentParser(IngestArgumentParser):
 
     def __init__(self, *args, **kwargs):
         super(DecamIngestArgumentParser, self).__init__(*args, **kwargs)
-        self.add_argument("--filetype", default="instcal", choices=["instcal", "raw"],
+        self.add_argument("--filetype", default="raw", choices=["instcal", "raw"],
                           help="Data processing level of the files to be ingested")
         self.description = "To ingest instcal data, the following directory structure is expected:"\
             "\n    dqmask/ instcal/ wtmap/"\


### PR DESCRIPTION
This PR replaces all use of `DecamIngestTask`'s default `--filetype` argument with an explicit one (preserving behavior), then changes the default of `--filetype`.