### PR TITLE
DM-12315: Generalize ap_pipe to non-HiTS data

### DIFF
--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -1,0 +1,9 @@
+# Config override for lsst.ap.pipe.ApPipeTask
+import os.path
+from lsst.utils import getPackageDir
+
+decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+
+config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcd.py"))
+config.associator.load(os.path.join(decamConfigDir, "association.py"))
+

--- a/config/association.py
+++ b/config/association.py
@@ -1,0 +1,6 @@
+# Config override for lsst.ap.association.AssociationTask
+from lsst.ap.association import AssociationDBSqliteTask
+
+config.level1_db.retarget(AssociationDBSqliteTask)
+config.level1_db.filter_names = ['u', 'g', 'r', 'i', 'z', 'y', 'VR']
+

--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -10,4 +10,5 @@ config.dataIngester.retarget(DecamIngestTask)
 config.dataIngester.load(os.path.join(decamConfigDir, 'ingest.py'))
 config.calibIngester.load(os.path.join(decamConfigDir, 'ingestCalibs.py'))
 config.defectIngester.load(os.path.join(decamConfigDir, 'ingestCalibs.py'))
+config.defectIngester.parse.extnames = []
 


### PR DESCRIPTION
This PR adds DECam-specific settings for `ApPipeTask` and `AssociationTask` to obs package override files.