### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -1,3 +1,6 @@
+"""
+DECam-specific overrides of IsrTask
+"""
 from lsst.obs.decam.crosstalk import DecamCrosstalkTask
 config.crosstalk.retarget(DecamCrosstalkTask)
 

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -1,12 +1,16 @@
+"""
+DECam-specific overrides for ProcessCcdTask
+"""
 import os.path
 
 from lsst.utils import getPackageDir
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 from lsst.obs.decam.isr import DecamIsrTask
-config.isr.retarget(DecamIsrTask)
 
-decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
-config.isr.load(os.path.join(decamConfigDir, 'isr.py'))
+obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+
+config.isr.retarget(DecamIsrTask)
+config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
 
 config.charImage.repair.cosmicray.nCrPixelMax = 100000
 

--- a/config/processCcdCpIsr.py
+++ b/config/processCcdCpIsr.py
@@ -1,12 +1,16 @@
+"""
+DECam-specific overrides for ProcessCcdTask/Community Pipeline products
+"""
 import os.path
 
 from lsst.utils import getPackageDir
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 from lsst.obs.decam.decamCpIsr import DecamCpIsrTask
-config.isr.retarget(DecamCpIsrTask)
 
-decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
-config.isr.load(os.path.join(decamConfigDir, 'isr.py'))
+obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+
+config.isr.retarget(DecamCpIsrTask)
+config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
 
 config.charImage.repair.cosmicray.nCrPixelMax = 100000
 

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -1,0 +1,12 @@
+"""
+DECam-specific overrides for RunIsrTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.decam.isr import DecamIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_decam"), "config")
+
+config.isr.retarget(DecamIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))

--- a/config/runIsrCp.py
+++ b/config/runIsrCp.py
@@ -1,0 +1,12 @@
+"""
+DECam-specific overrides for RunIsrTask/Community Pipeline products
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.decam.decamCpIsr import DecamCpIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_decam"), "config")
+
+config.isr.retarget(DecamCpIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
