### PR TITLE
DM-19382: Update test value for interpolation changes.

### DIFF
--- a/policy/DecamMapper.yaml
+++ b/policy/DecamMapper.yaml
@@ -35,6 +35,8 @@ exposures:
     template: '%(date)s/%(filter)s/decam%(visit)07d.fits.fz[%(hdu)d]'
   postISRCCD:
     template: '%(visit)07d/postISR/postISR-%(visit)07d_%(ccdnum)02d.fits'
+  postISRCCD_uninterpolated:
+    template: '%(visit)07d/postISR/postISR-%(visit)07d_%(ccdnum)02d_preInterp.fits'
   instcal:
     level: ccd
     persistable: DecoratedImageF

--- a/tests/test_crosstalk.py
+++ b/tests/test_crosstalk.py
@@ -124,8 +124,8 @@ class CrosstalkTestCase(lsst.utils.tests.TestCase):
         self.assertAlmostEqual(chunk1.getArray().mean(), 3730.96, places=2)
         self.assertAlmostEqual(chunk2.getArray().mean(), 3727.55, places=2)
         self.assertAlmostEqual(chunkDiff.getArray().mean(), 3.41, places=2)
-        self.assertAlmostEqual(chunk1.getArray().std(), 33.81, places=2)
-        self.assertAlmostEqual(chunk2.getArray().std(), 33.32, places=2)
+        self.assertAlmostEqual(chunk1.getArray().std(), 33.80, places=2)
+        self.assertAlmostEqual(chunk2.getArray().std(), 33.31, places=2)
         self.assertAlmostEqual(chunkDiff.getArray().std(), 5.86, places=2)
 
         # Option to display the portions of the image with/without crosstalk


### PR DESCRIPTION
Previously, masking and interpolation was done on a by-defect-type
basis: a set of bad pixels were masked and interpolated, then the
process repeated on different bad pixels. However, this ignores the
case where different types of bad pixels may be contiguous, resulting
in interpolated pixels being derived based on previously interpolated
values.

After reordering, unit test check values are slightly different.