### PR TITLE
DM-23616: Run converted ap_verify testdata through gen3 pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,3 @@ Documentation of the LSST Science Pipelines is at https://pipelines.lsst.io
 
         from lsst.obs.decam.decamNullIsr import DecamNullIsrTask
         config.isr.retarget(DecamNullIsrTask)
-
-7. To process raw data with the Community-Pipeline calibration products, retarget the ISR task to `DecamCpIsrTask` by using the config override file config/processCcdCpIsr.py

--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -1,8 +1,7 @@
 # Config override for lsst.ap.pipe.ApPipeTask
 import os.path
-from lsst.utils import getPackageDir
 
-decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+decamConfigDir = os.path.dirname(__file__)
 
 # This default processCcd config assumes calibration products are from the
 # DECam Community Pipeline (CP). The config file to use for stack-built

--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -3,7 +3,4 @@ import os.path
 
 decamConfigDir = os.path.dirname(__file__)
 
-# This default processCcd config assumes calibration products are from the
-# DECam Community Pipeline (CP). The config file to use for stack-built
-# calibs is "processCcd.py" instead.
-config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcdCpIsr.py"))
+config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcd.py"))

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -1,0 +1,23 @@
+"""
+DECam-specific overrides for CalibrateTask
+"""
+
+# This sets the reference catalog name for Gen2.
+for refObjLoader in (config.astromRefObjLoader,
+                     config.photoRefObjLoader,
+                     ):
+    refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+    # Note the u-band results may not be useful without a color term
+    refObjLoader.filterMap['u'] = 'g'
+    refObjLoader.filterMap['Y'] = 'y'
+
+# This sets up the reference catalog for Gen3.
+config.connections.astromRefCat = "ps1_pv3_3pi_20170110"
+config.connections.photoRefCat = "ps1_pv3_3pi_20170110"
+config.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
+
+# this was the default prior to DM-11521.  New default is 2000.
+config.deblend.maxFootprintSize = 0
+
+# Set SIP order to 4, the Task default before RFC-577 to maintain same behavior
+config.astrometry.wcsFitter.order = 4

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -16,8 +16,5 @@ config.connections.astromRefCat = "ps1_pv3_3pi_20170110"
 config.connections.photoRefCat = "ps1_pv3_3pi_20170110"
 config.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
 
-# this was the default prior to DM-11521.  New default is 2000.
-config.deblend.maxFootprintSize = 0
-
 # Set SIP order to 4, the Task default before RFC-577 to maintain same behavior
 config.astrometry.wcsFitter.order = 4

--- a/config/characterizeImage.py
+++ b/config/characterizeImage.py
@@ -1,0 +1,12 @@
+"""
+DECam-specific overrides for CharacterizeImageTask
+"""
+config.repair.cosmicray.nCrPixelMax = 100000
+
+# This sets the reference catalog name for Gen2.
+# Note that in Gen3, we've stopped pretending (which is what Gen2 does,
+# for backwards compatibility) that charImage uses a reference catalog.
+config.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+# Note the u-band results may not be useful without a color term
+config.refObjLoader.filterMap['u'] = 'g'
+config.refObjLoader.filterMap['Y'] = 'y'

--- a/config/isr.py
+++ b/config/isr.py
@@ -49,7 +49,8 @@ config.doAssembleIsrExposures = False
 config.doTrimToMatchCalib = True
 
 config.doBias = True
-config.biasDataProductName = "cpBias"
+config.connections.bias = "cpBias"
+config.biasDataProductName = config.connections.bias
 
 config.doVariance = True
 config.gain = float("NaN")
@@ -73,12 +74,14 @@ config.doSaturationInterpolation = True
 config.numEdgeSuspect=35
 
 config.doDark = False
-config.darkDataProductName = "dark"
+config.connections.dark = "dark"
+config.darkDataProductName = config.connections.dark
 
 config.doStrayLight = False
 
 config.doFlat = True
-config.flatDataProductName = "cpFlat"
+config.connections.flat = "cpFlat"
+config.flatDataProductName = config.connections.flat
 config.flatScalingType = "USER"
 config.flatUserScale = 1.0
 config.doTweakFlat = False
@@ -107,6 +110,7 @@ config.doUseAtmosphereTransmission = False
 
 # Illumination correction should almost certainly be done,
 # but not all decam datasets yet have the necessary calibration products.
+# Nor is it supported yet in Gen 3
 config.doIlluminationCorrection = False
 # config.doIlluminationCorrection = True
 config.illuminationCorrectionDataProductName = "cpIllumcor"

--- a/config/isr.py
+++ b/config/isr.py
@@ -10,8 +10,6 @@ config.fallbackFilterName = None
 config.expectWcs = True
 config.fwhm = 1.0
 
-config.doConvertIntToFloat = False
-
 config.doSaturation=True
 config.saturatedMaskName = "SAT"
 config.saturation = float("NaN")

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -3,9 +3,7 @@ DECam-specific overrides for ProcessCcdTask
 """
 import os.path
 
-from lsst.utils import getPackageDir
-
-obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+obsConfigDir = os.path.dirname(__file__)
 
 config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
 config.charImage.load(os.path.join(obsConfigDir, 'characterizeImage.py'))

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -9,23 +9,4 @@ obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
 
 config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
 config.charImage.load(os.path.join(obsConfigDir, 'characterizeImage.py'))
-
-# This sets the reference catalog name for Gen2.
-for refObjLoader in (config.calibrate.astromRefObjLoader,
-                     config.calibrate.photoRefObjLoader,
-                     ):
-    refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
-    # Note the u-band results may not be useful without a color term
-    refObjLoader.filterMap['u'] = 'g'
-    refObjLoader.filterMap['Y'] = 'y'
-
-# This sets up the reference catalog for Gen3.
-config.calibrate.connections.astromRefCat = "ps1_pv3_3pi_20170110"
-config.calibrate.connections.photoRefCat = "ps1_pv3_3pi_20170110"
-
-config.calibrate.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
-# this was the default prior to DM-11521.  New default is 2000.
-config.calibrate.deblend.maxFootprintSize = 0
-
-# Set SIP order to 4, the Task default before RFC-577 to maintain same behavior
-config.calibrate.astrometry.wcsFitter.order = 4
+config.calibrate.load(os.path.join(obsConfigDir, 'calibrate.py'))

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -8,13 +8,11 @@ from lsst.utils import getPackageDir
 obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
 
 config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
-
-config.charImage.repair.cosmicray.nCrPixelMax = 100000
+config.charImage.load(os.path.join(obsConfigDir, 'characterizeImage.py'))
 
 # This sets the reference catalog name for Gen2.
 for refObjLoader in (config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader,
-                     config.charImage.refObjLoader,
                      ):
     refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
     # Note the u-band results may not be useful without a color term
@@ -22,8 +20,6 @@ for refObjLoader in (config.calibrate.astromRefObjLoader,
     refObjLoader.filterMap['Y'] = 'y'
 
 # This sets up the reference catalog for Gen3.
-# Note that in Gen3, we've stopped pretending (which is what Gen2 does,
-# for backwards compatibility) that charImage uses a reference catalog.
 config.calibrate.connections.astromRefCat = "ps1_pv3_3pi_20170110"
 config.calibrate.connections.photoRefCat = "ps1_pv3_3pi_20170110"
 

--- a/config/processCcdCpIsr.py
+++ b/config/processCcdCpIsr.py
@@ -8,12 +8,10 @@ from lsst.utils import getPackageDir
 obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
 
 config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
-
-config.charImage.repair.cosmicray.nCrPixelMax = 100000
+config.charImage.load(os.path.join(obsConfigDir, 'characterizeImage.py'))
 
 for refObjLoader in (config.calibrate.astromRefObjLoader,
                      config.calibrate.photoRefObjLoader,
-                     config.charImage.refObjLoader,
                      ):
     refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
     # Note the u-band results may not be useful without a color term

--- a/config/processCcdCpIsr.py
+++ b/config/processCcdCpIsr.py
@@ -2,9 +2,13 @@
 DECam-specific overrides for ProcessCcdTask/Community Pipeline products
 """
 import os.path
+import warnings
 
 obsConfigDir = os.path.dirname(__file__)
 
-config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
-config.charImage.load(os.path.join(obsConfigDir, 'characterizeImage.py'))
-config.calibrate.load(os.path.join(obsConfigDir, 'calibrate.py'))
+config.load(os.path.join(obsConfigDir, 'processCcd.py'))
+
+warnings.warn(
+    'processCcdCpIsr.py is no longer needed, use processCcd.py instead. Will '
+    'be removed after release 21.0',
+    category=FutureWarning)

--- a/config/processCcdCpIsr.py
+++ b/config/processCcdCpIsr.py
@@ -3,9 +3,7 @@ DECam-specific overrides for ProcessCcdTask/Community Pipeline products
 """
 import os.path
 
-from lsst.utils import getPackageDir
-
-obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+obsConfigDir = os.path.dirname(__file__)
 
 config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
 config.charImage.load(os.path.join(obsConfigDir, 'characterizeImage.py'))

--- a/config/processCcdCpIsr.py
+++ b/config/processCcdCpIsr.py
@@ -9,15 +9,4 @@ obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
 
 config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
 config.charImage.load(os.path.join(obsConfigDir, 'characterizeImage.py'))
-
-for refObjLoader in (config.calibrate.astromRefObjLoader,
-                     config.calibrate.photoRefObjLoader,
-                     ):
-    refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
-    # Note the u-band results may not be useful without a color term
-    refObjLoader.filterMap['u'] = 'g'
-    refObjLoader.filterMap['Y'] = 'y'
-
-config.calibrate.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
-config.calibrate.connections.astromRefCat = "ps1_pv3_3pi_20170110"
-config.calibrate.connections.photoRefCat = "ps1_pv3_3pi_20170110"
+config.calibrate.load(os.path.join(obsConfigDir, 'calibrate.py'))

--- a/python/lsst/obs/decam/crosstalk.py
+++ b/python/lsst/obs/decam/crosstalk.py
@@ -197,9 +197,9 @@ class DecamCrosstalkTask(CrosstalkTask):
                         applied (`lsst.afw.image.Exposure`).
         """
         self.log.info('Applying crosstalk correction')
-        assert crosstalkSources is not None, "Sources are required for DECam crosstalk correction; \
-                                              you must run CrosstalkTask via IsrTask which will \
-                                              call prepCrosstalk to get the sources."
+        assert crosstalkSources is not None, "Sources are required for DECam crosstalk correction; " \
+                                             "you must run CrosstalkTask via IsrTask which will " \
+                                             "call prepCrosstalk to get the sources."
         # Load data from crosstalk 'victim' exposure we want to correct
         det = exposure.getDetector()
         for amp in det:

--- a/tests/nopytest_test_processCcd.py
+++ b/tests/nopytest_test_processCcd.py
@@ -51,13 +51,10 @@ class ProcessCcdTestCase(lsst.utils.tests.TestCase):
 
         cls.outPath = tempfile.mkdtemp() if OutputName is None else OutputName
         cls.dataId = {'visit': 229388, 'ccdnum': 1}
-        configPath = os.path.join(getPackageDir("obs_decam"), "config")
         argsList = [os.path.join(cls.datadir, "rawData"), "--output", cls.outPath, "--id"]
         argsList += ["%s=%s" % (key, val) for key, val in cls.dataId.items()]
         argsList += ["--calib", os.path.join(cls.datadir, "rawData/cpCalib")]
-        argsList += ["--config", "calibrate.doPhotoCal=False", "calibrate.doAstrometry=False",
-                     # This test uses CP-MasterCal calibration products
-                     "-C", "%s/processCcdCpIsr.py" % configPath]
+        argsList += ["--config", "calibrate.doPhotoCal=False", "calibrate.doAstrometry=False"]
         argsList.append('--doraise')
         disableImplicitThreading()  # avoid contention with other processes
         fullResult = ProcessCcdTask.parseAndRun(args=argsList, doReturnResults=True)


### PR DESCRIPTION
This PR changes `obs_decam` configuration files to be appropriate for Gen 3. It also performs some general cleanup inspired by discussion on `#dm-alert-prod`.