### PR TITLE
DM-23651: ap_pipe calls some deprecated things

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -93,8 +93,6 @@ config.fringe.filters = ['z', 'y']
 
 config.doNanInterpAfterFlat = False
 
-config.doAddDistortionModel = False  # rely on the TPV terms instead
-
 config.doMeasureBackground = True
 
 config.doCameraSpecificMasking = False


### PR DESCRIPTION
This PR removes all references to the `IsrConfig.doAddDistortionModel` field, which is no longer  used by `IsrTask`.