### PR TITLE
DM-24495: Switch to using __file__ to reference other configs.

### DIFF
--- a/config/coaddDriver.py
+++ b/config/coaddDriver.py
@@ -1,9 +1,7 @@
 # Load from sub-configurations
 import os.path
 
-from lsst.utils import getPackageDir
-
 for sub in ("makeCoaddTempExp", "backgroundReference", "assembleCoadd", "detectCoaddSources"):
-    path = os.path.join(getPackageDir("obs_decam"), "config", sub + ".py")
+    path = os.path.join(os.path.dirname(__file__), sub + ".py")
     if os.path.exists(path):
         getattr(config, sub).load(path)

--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -1,10 +1,9 @@
 # Config override for lsst.ap.verify.DatasetIngestTask
 import os.path
 
-from lsst.utils import getPackageDir
 from lsst.obs.decam.ingest import DecamIngestTask
 
-decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+decamConfigDir = os.path.dirname(__file__)
 
 config.textDefectPath = os.path.join(getPackageDir('obs_decam_data'), 'decam', 'defects')
 config.dataIngester.retarget(DecamIngestTask)

--- a/config/multiBandDriver.py
+++ b/config/multiBandDriver.py
@@ -1,9 +1,7 @@
 # Load from sub-configurations
 import os.path
 
-from lsst.utils import getPackageDir
-
 for sub in ("mergeCoaddDetections", "measureCoaddSources", "mergeCoaddMeasurements", "forcedPhotCoadd"):
-    path = os.path.join(getPackageDir("obs_decam"), "config", sub + ".py")
+    path = os.path.join(os.path.dirname(__file__), sub + ".py")
     if os.path.exists(path):
         getattr(config, sub).load(path)

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -3,8 +3,6 @@ DECam-specific overrides for RunIsrTask
 """
 import os.path
 
-from lsst.utils import getPackageDir
-
-obsConfigDir = os.path.join(getPackageDir("obs_decam"), "config")
+obsConfigDir = os.path.join(os.path.dirname(__file__))
 
 config.isr.load(os.path.join(obsConfigDir, "isr.py"))

--- a/config/runIsrCp.py
+++ b/config/runIsrCp.py
@@ -3,8 +3,6 @@ DECam-specific overrides for RunIsrTask/Community Pipeline products
 """
 import os.path
 
-from lsst.utils import getPackageDir
-
-obsConfigDir = os.path.join(getPackageDir("obs_decam"), "config")
+obsConfigDir = os.path.join(os.path.dirname(__file__))
 
 config.isr.load(os.path.join(obsConfigDir, "isr.py"))

--- a/config/singleFrameDriver.py
+++ b/config/singleFrameDriver.py
@@ -1,6 +1,4 @@
 import os
 
-from lsst.utils import getPackageDir
-
-config.processCcd.load(os.path.join(getPackageDir("obs_decam"), "config", "processCcd.py"))
+config.processCcd.load(os.path.join(os.path.dirname(__file__), "processCcd.py"))
 config.ccdKey = 'ccdnum'


### PR DESCRIPTION
See https://community.lsst.org/t/pex-config-configs-now-know-where-they-are/4023.