### PR TITLE
DM-17538: Generate stack-produced (rather than CP) calibration products for DECam

### DIFF
--- a/python/lsst/obs/decam/ingest.py
+++ b/python/lsst/obs/decam/ingest.py
@@ -245,10 +245,6 @@ class DecamParseTask(ParseTask):
 
         return phuInfo, infoList
 
-    @staticmethod
-    def getExtensionName(md):
-        return md.getScalar('EXTNAME')
-
     def getDestination(self, butler, info, filename, filetype="raw"):
         """Get destination for the file
 

--- a/python/lsst/obs/decam/ingestCalibs.py
+++ b/python/lsst/obs/decam/ingestCalibs.py
@@ -135,23 +135,6 @@ class DecamCalibsParseTask(CalibsParseTask):
         else:
             return "unknown"
 
-    @staticmethod
-    def getExtensionName(md):
-        """Get the name of the extension.
-
-        Parameters
-        ----------
-        md : `lsst.daf.base.PropertySet`
-            FITS header metadata.
-
-        Returns
-        -------
-        result : `str`
-            The string from the EXTNAME header card, or None.
-        """
-        ext = md.get("EXTNAME", None)
-        return ext
-
     def getDestination(self, butler, info, filename):
         """Get destination for the file.
 

--- a/python/lsst/obs/decam/ingestCalibs.py
+++ b/python/lsst/obs/decam/ingestCalibs.py
@@ -1,12 +1,19 @@
 
 import collections.abc
 import re
+from lsst.afw.fits import readMetadata
 from lsst.pipe.tasks.ingestCalibs import CalibsParseTask
 
 __all__ = ["DecamCalibsParseTask"]
 
 
 class DecamCalibsParseTask(CalibsParseTask):
+    """Parse calibration products for ingestion.
+
+    Handle either DECam Community Pipeline calibration products or
+    calibration products produced with the LSST Science Pipelines
+    (i.e., pipe_drivers' constructBias.py and constructFlat.py).
+    """
 
     def getInfo(self, filename):
         """Get information about the image from the filename and/or its contents.
@@ -52,7 +59,7 @@ class DecamCalibsParseTask(CalibsParseTask):
         Calibration products made with constructCalibs have some metadata
         saved in its FITS header CALIB_ID.
         """
-        data = md.getScalar("CALIB_ID")
+        data = md["CALIB_ID"]
         match = re.search(r".*%s=(\S+)" % field, data)
         return match.groups()[0]
 
@@ -64,8 +71,8 @@ class DecamCalibsParseTask(CalibsParseTask):
         md : `lsst.daf.base.PropertySet`
             FITS header metadata.
         """
-        if md.exists("CCDNUM"):
-            ccdnum = md.getScalar("CCDNUM")
+        if "CCDNUM" in md:
+            ccdnum = md["CCDNUM"]
         else:
             return self._translateFromCalibId("ccdnum", md)
         # Some MasterCal from NOAO Archive has 2 CCDNUM keys in each HDU
@@ -86,15 +93,15 @@ class DecamCalibsParseTask(CalibsParseTask):
         md : `lsst.daf.base.PropertySet`
             FITS header metadata.
         """
-        if md.exists("DATE-OBS"):
-            date = md.getScalar("DATE-OBS")
+        if "DATE-OBS" in md:
+            date = md["DATE-OBS"]
             found = re.search(r'(\d\d\d\d-\d\d-\d\d)', date)
             if found:
                 date = found.group(1)
             else:
                 self.log.warn("DATE-OBS does not match format YYYY-MM-DD")
                 date = "unknown"
-        elif md.exists("CALIB_ID"):
+        elif "CALIB_ID" in md:
             date = self._translateFromCalibId("calibDate", md)
         else:
             date = "unknown"
@@ -112,11 +119,18 @@ class DecamCalibsParseTask(CalibsParseTask):
         md : `lsst.daf.base.PropertySet`
             FITS header metadata.
         """
-        if md.exists("FILTER"):
-            if md.exists("OBSTYPE") and "zero" in md.getScalar("OBSTYPE").strip().lower():
-                return "NONE"
-            return CalibsParseTask.translate_filter(self, md)
-        elif md.exists("CALIB_ID"):
+        if "FILTER" in md:
+            if "OBSTYPE" in md:
+                obstype = md["OBSTYPE"].strip().lower()
+                if "zero" in obstype or "bias" in obstype:
+                    return "NONE"
+            filterName = CalibsParseTask.translate_filter(self, md)
+            # TODO (DM-24514): remove workaround if/else
+            if filterName == '_unknown_' and "CALIB_ID" in md:
+                return self._translateFromCalibId("filter", md)
+            else:
+                return CalibsParseTask.translate_filter(self, md)
+        elif "CALIB_ID" in md:
             return self._translateFromCalibId("filter", md)
         else:
             return "unknown"
@@ -133,9 +147,10 @@ class DecamCalibsParseTask(CalibsParseTask):
         Returns
         -------
         result : `str`
-            The string from the EXTNAME header card.
+            The string from the EXTNAME header card, or None.
         """
-        return md.getScalar('EXTNAME')
+        ext = md.get("EXTNAME", None)
+        return ext
 
     def getDestination(self, butler, info, filename):
         """Get destination for the file.
@@ -154,18 +169,26 @@ class DecamCalibsParseTask(CalibsParseTask):
         raw : `str`
             Destination filename.
         """
-        # Arbitrarily set ccdnum and calib_hdu to 1 to make the mapper template happy
-        info["ccdnum"] = 1
-        info["calib_hdu"] = 1
         calibType = self.getCalibType(filename)
-        if "flat" in calibType.lower():
-            raw = butler.get("cpFlat_filename", info)[0]
-        elif ("bias" or "zero") in calibType.lower():
-            raw = butler.get("cpBias_filename", info)[0]
-        elif ("illumcor") in calibType.lower():
-            raw = butler.get("cpIllumcor_filename", info)[0]
-        else:
-            assert False, "Invalid calibType '{:s}'".format(calibType)
+        md = readMetadata(filename, self.config.hdu)
+        if "PROCTYPE" not in md:
+            raise RuntimeError(f"Unable to find the calib header keyword PROCTYPE \
+                               in {filename}, hdu {self.config.hdu}")
+        proctype = md["PROCTYPE"].strip()
+        if "MasterCal" in proctype:  # DECam Community Pipeline calibration product case
+            # Arbitrarily set ccdnum and calib_hdu to 1 to make the mapper template happy
+            info["ccdnum"] = 1
+            info["calib_hdu"] = 1
+            if "flat" in calibType.lower():
+                raw = butler.get("cpFlat_filename", info)[0]
+            elif ("bias" or "zero") in calibType.lower():
+                raw = butler.get("cpBias_filename", info)[0]
+            elif ("illumcor") in calibType.lower():
+                raw = butler.get("cpIllumcor_filename", info)[0]
+            else:
+                raise RuntimeError(f"Invalid DECam Community Pipeline calibType {calibType}")
+        else:  # LSST-built calibration product case
+            raw = butler.get(calibType + "_filename", info)[0]
         # Remove HDU extension (ccdnum) since we want to refer to the whole file
         c = raw.find("[")
         if c > 0:

--- a/tests/test_parseCalibsGen2.py
+++ b/tests/test_parseCalibsGen2.py
@@ -1,0 +1,157 @@
+# This file is part of obs_decam.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for gen2 DECam calibration product parsing, a precursor to ingestion.
+"""
+
+import unittest
+import os
+import lsst.utils.tests
+from lsst.obs.decam import ingestCalibs
+import lsst.daf.persistence as dafPersist
+from lsst.afw.fits import readMetadata
+
+testDataPackage = "testdata_decam"
+try:
+    testDataDirectory = lsst.utils.getPackageDir(testDataPackage)
+except LookupError:
+    testDataDirectory = None
+
+
+@unittest.skipIf(testDataDirectory is None, "testdata_decam must be set up")
+class DecamCalibsParseTaskTestCase(lsst.utils.tests.TestCase):
+    """Test the methods in DecamCalibsParseTask.
+
+    Uses a bias+flat pair of LSST-Science-Pipeline-built calibs as well as
+    a bias+flat pair of DECam Community Pipeline calibs, all full of zeros,
+    which live in testdata_decam.
+    """
+    def setUp(self):
+        self.task = ingestCalibs.DecamCalibsParseTask(name='ItsATest')
+
+        # LSST-Science-Pipeline-built calibration products, full of zeros
+        self.biasFile = os.path.join(testDataDirectory, "pipeline-calibs", "BIAS", "BIAS-47.fits")
+        self.flatFile = os.path.join(testDataDirectory, "pipeline-calibs", "FLAT", "FLAT-g-47.fits")
+
+        # DECam Community Pipeline calibration products, also full of zeros
+        cpBiasFilename = "c4d_150218_191721_zci_v1.fits.fz"
+        self.cpBiasFile = os.path.join(testDataDirectory, "hits2015-zeroed", cpBiasFilename)
+        cpFlatFilename = "c4d_150218_200522_fci_g_v1.fits.fz"
+        self.cpFlatFile = os.path.join(testDataDirectory, "hits2015-zeroed", cpFlatFilename)
+
+        # A Butler repository with ingested raws and Community Pipeline calibs
+        repo = os.path.join(testDataDirectory, "ingested")
+        calibRepo = os.path.join(testDataDirectory, "calibingested")
+        self.butler = dafPersist.Butler(root=repo, calibRoot=calibRepo)
+
+    def checkGetInfo(self, filename):
+        """Test that the filepath and a calib_hdu value of 1 is in the info.
+        """
+        phuInfo, infoList = self.task.getInfo(filename)
+        self.assertEqual(phuInfo['calib_hdu'], 1)
+        self.assertIn('path', phuInfo)
+        for item in infoList:
+            self.assertEqual(item['calib_hdu'], 1)
+            self.assertIn('path', item)
+
+    def testLsstCalibsGetInfo(self):
+        """Test that the filepath and a calib_hdu value of 1 is in the info.
+        """
+        # LSST-Science-Pipelines-built bias
+        self.checkGetInfo(self.biasFile)
+
+        # LSST-Science-Pipelines-built flat
+        self.checkGetInfo(self.flatFile)
+
+    def testLsstCalibsGetDestination(self):
+        """Test that file path destinations conform to the mapper templates.
+        """
+        # LSST-Science-Pipelines-built bias
+        dataId = {'ccdnum': 1, 'date': '2015-02-18'}
+        filename = self.task.getDestination(self.butler, dataId, self.biasFile)
+        self.assertIn(f"BIAS/{dataId['date']}/BIAS-{dataId['date']}-{dataId['ccdnum']:02}.fits", filename)
+        self.assertNotIn('[', filename)
+
+        # LSST-Science-Pipelines-built flat
+        dataId = {'ccdnum': 1, 'date': '2015-02-18', 'filter': 'g'}
+        filename = self.task.getDestination(self.butler, dataId, self.flatFile)
+        self.assertIn(f"FLAT/{dataId['date']}/{dataId['filter']}/"
+                      + f"FLAT-{dataId['date']}-{dataId['ccdnum']:02}.fits", filename)
+        self.assertNotIn('[', filename)
+
+    def testLsstCalibsTranslateFilter(self):
+        """Test that filter is set to "NONE" for the bias and "g" for the flat.
+        """
+        # LSST-Science-Pipelines-built bias
+        md = readMetadata(self.biasFile, self.task.config.hdu)
+        biasFilter = self.task.translate_filter(md)
+        self.assertEqual(biasFilter, "NONE")
+
+        # LSST-Science-Pipelines-built flat
+        md = readMetadata(self.flatFile, self.task.config.hdu)
+        flatFilter = self.task.translate_filter(md)
+        self.assertEqual(flatFilter, "g")
+
+    def testCpCalibsGetInfo(self):
+        """Test that the filepath and a calib_hdu value of 1 is in the info.
+        """
+        # DECam Community Pipeline bias
+        self.checkGetInfo(self.cpBiasFile)
+
+        # DECam Community Pipeline flat
+        self.checkGetInfo(self.cpFlatFile)
+
+    def testCpCalibsGetDestination(self):
+        """Test that file path destinations conform to the mapper templates.
+        """
+        # DECam Community Pipeline bias
+        dataId = {'ccdnum': 1, 'date': '2015-02-18'}
+        filename = self.task.getDestination(self.butler, dataId, self.cpBiasFile)
+        self.assertIn(f"cpBIAS/{dataId['date']}/BIAS-{dataId['date']}.fits", filename)
+        self.assertNotIn('[', filename)
+
+        # DECam Community Pipeline flat
+        dataId = {'ccdnum': 1, 'date': '2015-02-18', 'filter': 'g'}
+        filename = self.task.getDestination(self.butler, dataId, self.cpFlatFile)
+        self.assertIn(f"cpFLAT/{dataId['date']}/{dataId['filter']}/FLAT-{dataId['date']}.fits", filename)
+        self.assertNotIn('[', filename)
+
+    def testCpCalibsTranslateFilter(self):
+        """Test that filter is set to "NONE" for the cpBias and "g" for the cpFlat.
+        """
+        # DECam Community Pipeline bias
+        md = readMetadata(self.cpBiasFile, self.task.config.hdu)
+        cpBiasFilter = self.task.translate_filter(md)
+        self.assertEqual(cpBiasFilter, "NONE")
+
+        # DECam Community Pipeline flat
+        md = readMetadata(self.cpFlatFile, self.task.config.hdu)
+        cpFlatFilter = self.task.translate_filter(md)
+        self.assertEqual(cpFlatFilter, "g")
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR enables obs_decam to ingest both CP (community pipeline) calibs and stack-built calibs. Previously we were only supporting CP calibs because nobody had built DECam master calibs with the stack before. I have now successfully constructed biases and (g-band) flats and ingested them.