### PR TITLE
DM-23983: Cannot apply crosstalk in Gen 3 DECam processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/runCrosstalkAlone.py
 repositoryCfg.yaml
 decam/CALIB/defects
 decam/CALIB/calibRegistry*
+decam/crosstalk

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ bin/processCcdDecam.py
 bin/runCrosstalkAlone.py
 repositoryCfg.yaml
 decam/CALIB/defects
+decam/CALIB/crosstalk
 decam/CALIB/calibRegistry*
 decam/crosstalk

--- a/config/ingestCuratedCalibs.py
+++ b/config/ingestCuratedCalibs.py
@@ -8,7 +8,7 @@ config.register.columns = {'filter': 'text',
                            'validStart': 'text',
                            'validEnd': 'text',
                            }
-config.register.tables = ['defects',]
+config.register.tables = ['defects', 'crosstalk']
 config.register.detector = ['filter', 'ccdnum']
 config.register.unique = ['filter', 'ccdnum', 'calibDate']
 config.register.visit = ['calibDate']

--- a/config/isr.py
+++ b/config/isr.py
@@ -3,7 +3,6 @@ DECam-specific overrides of IsrTask
 """
 import os.path
 
-from lsst.obs.decam.crosstalk import DecamCrosstalkTask
 
 config.datasetType = "raw"
 config.fallbackFilterName = None
@@ -59,7 +58,6 @@ config.doLinearize = True
 
 config.doCrosstalkBeforeAssemble = True
 config.doCrosstalk = True
-config.crosstalk.retarget(DecamCrosstalkTask)
 config.crosstalk.minPixelToMask=45000.0
 config.crosstalk.crosstalkMaskPlane="CROSSTALK"
 

--- a/config/isr.py
+++ b/config/isr.py
@@ -3,6 +3,7 @@ DECam-specific overrides of IsrTask
 """
 import os.path
 
+from lsst.obs.decam.crosstalk import DecamCrosstalkTask
 
 config.datasetType = "raw"
 config.fallbackFilterName = None
@@ -58,6 +59,7 @@ config.doLinearize = True
 
 config.doCrosstalkBeforeAssemble = True
 config.doCrosstalk = True
+config.crosstalk.retarget(DecamCrosstalkTask)
 config.crosstalk.minPixelToMask=45000.0
 config.crosstalk.crosstalkMaskPlane="CROSSTALK"
 

--- a/decam/SConscript
+++ b/decam/SConscript
@@ -43,3 +43,20 @@ command = (f"{python} {pipe_tasks_dir}/bin/ingestCuratedCalibs.py decam/CALIB/ {
             "--calib decam/CALIB --config clobber=True")
 commandInst = env.Command('CALIB/calibRegistry.sqlite3', [], command)
 env.Depends(commandInst, lsst.sconsUtils.targets["python"])
+
+
+# Create crosstalk tables
+def getCrosstalkInFile():
+    crosstalkInFiles = glob.glob("DECam_xtalk_*.txt")
+    if len(crosstalkInFiles) == 1:
+        return crosstalkInFiles[0]
+    elif len(crosstalkInFiles) == 0:
+        raise RuntimeError("Could not find a crosstalk table")
+    else:
+        raise RuntimeError("Found %s crosstalk tables; need just one" % (len(crosstalkInFiles),))
+
+crosstalkInFile = getCrosstalkInFile()
+crosstalkOutDir = "decam/crosstalk"
+command = "%s decam/makeCrosstalkDecam.py $SOURCE --force" % (python,)
+
+makeCrosstalk = env.Command(crosstalkOutDir, crosstalkInFile, command)

--- a/decam/SConscript
+++ b/decam/SConscript
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-# Build the linearity tables
+# Build the linearity, defect, and crosstalk tables
 # This code was adapted from obs_subaru hsc/SConscript
 
 import lsst.sconsUtils
@@ -45,7 +45,7 @@ commandInst = env.Command('CALIB/calibRegistry.sqlite3', [], command)
 env.Depends(commandInst, lsst.sconsUtils.targets["python"])
 
 
-# Create crosstalk tables
+# Create crosstalk calibration tables by parsing the ascii table
 def getCrosstalkInFile():
     crosstalkInFiles = glob.glob("DECam_xtalk_*.txt")
     if len(crosstalkInFiles) == 1:
@@ -61,7 +61,9 @@ command = "%s decam/makeCrosstalkDecam.py $SOURCE --force" % (python,)
 
 makeCrosstalk = env.Command(crosstalkOutDir, crosstalkInFile, command)
 
-# Ingest crosstalk
+# Ingest crosstalk calibration tables into decam/CALIB with
+# ingestCuratedCalibs.py so they can be found by butlers using this
+# build of obs_decam.
 decam_dir = lsst.sconsUtils.env.ProductDir('obs_decam')
 command = (f"{python} {pipe_tasks_dir}/bin/ingestCuratedCalibs.py decam/CALIB/ {decam_dir}/decam/crosstalk "+
            "--calib decam/CALIB --config clobber=True")

--- a/decam/SConscript
+++ b/decam/SConscript
@@ -56,7 +56,14 @@ def getCrosstalkInFile():
         raise RuntimeError("Found %s crosstalk tables; need just one" % (len(crosstalkInFiles),))
 
 crosstalkInFile = getCrosstalkInFile()
-crosstalkOutDir = "decam/crosstalk"
+crosstalkOutDir = "decam/crosstalk/1970-01-01T00:00:00/"
 command = "%s decam/makeCrosstalkDecam.py $SOURCE --force" % (python,)
 
 makeCrosstalk = env.Command(crosstalkOutDir, crosstalkInFile, command)
+
+# Ingest crosstalk
+decam_dir = lsst.sconsUtils.env.ProductDir('obs_decam')
+command = (f"{python} {pipe_tasks_dir}/bin/ingestCuratedCalibs.py decam/CALIB/ {decam_dir}/decam/crosstalk "+
+           "--calib decam/CALIB --config clobber=True")
+commandCrosstalkIng = env.Command('CALIB/calibRegistry.sqlite3', [], command)
+env.Depends(commandCrosstalkIng, lsst.sconsUtils.targets["python"])

--- a/decam/makeCrosstalkDecam.py
+++ b/decam/makeCrosstalkDecam.py
@@ -22,7 +22,8 @@ def makeDetectorCrosstalk(dataDict, force=False):
     dataDict['coeffs'] = dataDict['coeffs'].transpose()
 
     decamCT = ipIsr.crosstalk.CrosstalkCalib.fromDict(dataDict)
-    decamCT.updateMetadata(setDate=True)
+    # Supply a date prior to all data, to ensure universal use.
+    decamCT.updateMetadata(setDate=False, CALIBDATE='1970-01-01T00:00:00')
 
     detName = dataDict['DETECTOR_NAME']
     outDir = os.path.join(DecamMapper.getCrosstalkDir(), detName.lower())
@@ -35,12 +36,12 @@ def makeDetectorCrosstalk(dataDict, force=False):
     decamCT.writeText(f"{outDir}/1970-01-01T00:00:00.yaml")
 
 
-def readFile(fromFile):
-    """Construct crosstalk dictionary-of-dictionaries from fromFile.
+def readFile(crosstalkInfile):
+    """Construct crosstalk dictionary-of-dictionaries from crosstalkInfile.
 
     Parameters
     ----------
-    fromFile : `str`
+    crosstalkInfile : `str`
         File containing crosstalk coefficient information.
 
     Results
@@ -71,7 +72,7 @@ def readFile(fromFile):
               }
     detSerialMap = {value: int(key.replace("ccd", '')) for key, value in detMap.items()}
     outDict = dict()
-    with open(fromFile) as f:
+    with open(crosstalkInfile) as f:
         for line in f:
             li = line.strip()
             if not li.startswith('#'):
@@ -133,12 +134,12 @@ def readFile(fromFile):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert a DECam crosstalk file into LSST CrosstalkCalibs.")
-    parser.add_argument(dest="fromFile", help="DECam crosstalk file.")
+    parser.add_argument(dest="crosstalkInfile", help="DECam crosstalk file.")
     parser.add_argument("-v", "--verbose", action="store_true", help="Print data about each detector.")
     parser.add_argument("-f", "--force", action="store_true", help="Overwrite existing CrosstalkCalibs.")
     cmd = parser.parse_args()
 
-    outDict = readFile(fromFile=cmd.fromFile)
+    outDict = readFile(crosstalkInfile=cmd.crosstalkInfile)
 
     crosstalkDir = DecamMapper.getCrosstalkDir()
     if os.path.exists(crosstalkDir):

--- a/decam/makeCrosstalkDecam.py
+++ b/decam/makeCrosstalkDecam.py
@@ -56,21 +56,11 @@ def readFile(crosstalkInfile):
         Raised if the detector is not known.
     """
     ampIndexMap = {'A': 0, 'B': 1}
-    detMap = {'ccd01': 'S29', 'ccd02': 'S30', 'ccd03': 'S31', 'ccd04': 'S25', 'ccd05': 'S26',
-              'ccd06': 'S27', 'ccd07': 'S28', 'ccd08': 'S20', 'ccd09': 'S21', 'ccd10': 'S22',
-              'ccd11': 'S23', 'ccd12': 'S24', 'ccd13': 'S14', 'ccd14': 'S15', 'ccd15': 'S16',
-              'ccd16': 'S17', 'ccd17': 'S18', 'ccd18': 'S19', 'ccd19': 'S8', 'ccd20': 'S9',
-              'ccd21': 'S10', 'ccd22': 'S11', 'ccd23': 'S12', 'ccd24': 'S13', 'ccd25': 'S1',
-              'ccd26': 'S2', 'ccd27': 'S3', 'ccd28': 'S4', 'ccd29': 'S5', 'ccd30': 'S6',
-              'ccd31': 'S7', 'ccd32': 'N1', 'ccd33': 'N2', 'ccd34': 'N3', 'ccd35': 'N4',
-              'ccd36': 'N5', 'ccd37': 'N6', 'ccd38': 'N7', 'ccd39': 'N8', 'ccd40': 'N9',
-              'ccd41': 'N10', 'ccd42': 'N11', 'ccd43': 'N12', 'ccd44': 'N13', 'ccd45': 'N14',
-              'ccd46': 'N15', 'ccd47': 'N16', 'ccd48': 'N17', 'ccd49': 'N18', 'ccd50': 'N19',
-              'ccd51': 'N20', 'ccd52': 'N21', 'ccd53': 'N22', 'ccd54': 'N23', 'ccd55': 'N24',
-              'ccd56': 'N25', 'ccd57': 'N26', 'ccd58': 'N27', 'ccd59': 'N28', 'ccd60': 'N29',
-              'ccd61': 'N30', 'ccd62': 'N31',
-              }
-    detSerialMap = {value: int(key.replace("ccd", '')) for key, value in detMap.items()}
+    detMap = {f"ccd{key:02d}": value for key, value in DecamMapper.detectorNames.items()}
+    detMap['ccd61'] = 'N30'
+    detSerialMap = {value: key for key, value in DecamMapper.detectorNames.items()}
+    detSerialMap['N30'] = 61
+
     outDict = dict()
     with open(crosstalkInfile) as f:
         for line in f:

--- a/decam/makeCrosstalkDecam.py
+++ b/decam/makeCrosstalkDecam.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Convert a DECam crosstalk text table into LSST CrosstalkCalibs.
+"""
+import argparse
+import numpy as np
+import os.path
+import sys
+
+import lsst.ip.isr as ipIsr
+from lsst.daf.base import PropertyList
+
+
+def makeDetectorCrosstalk(dataDict):
+    """Generate and write CrosstalkCalib from dictionary.
+
+    Parameters
+    ----------
+    dataDict : `dict`
+        Dictionary from ``readFile`` containing crosstalk definition.
+    """
+    decamCT = ipIsr.crosstalk.CrosstalkCalib()
+    decamCT.fromDict(dataDict)
+    decamCT.updateMetadata(setDate=True)
+
+    detName = dataDict['DETECTOR']
+    decamCT.writeFits(f"./crosstalk/{detName}.fits")
+
+
+def readFile(fromFile):
+    """Construct crosstalk dictionary-of-dictionaries from fromFile.
+
+    Parameters
+    ----------
+    fromFile : `str`
+        File containing crosstalk coefficient information.
+
+    Results
+    -------
+    outDict : `dict` [`str` : `dict`]
+        Output dictionary, keyed on victim detector names, containing
+        `lsst.ip.isr.CrosstalkCalib`'s expected dictionary format.
+
+    Raises
+    ------
+    RuntimeError :
+        Raised if the detector is not known.
+    """
+    ampIndexMap = {'A': 0, 'B': 1}
+    detMap = {'ccd01': 'S29', 'ccd02': 'S30', 'ccd03': 'S31', 'ccd04': 'S25', 'ccd05': 'S26',
+              'ccd06': 'S27', 'ccd07': 'S28', 'ccd08': 'S20', 'ccd09': 'S21', 'ccd10': 'S22',
+              'ccd11': 'S23', 'ccd12': 'S24', 'ccd13': 'S14', 'ccd14': 'S15', 'ccd15': 'S16',
+              'ccd16': 'S17', 'ccd17': 'S18', 'ccd18': 'S19', 'ccd19': 'S8', 'ccd20': 'S9',
+              'ccd21': 'S10', 'ccd22': 'S11', 'ccd23': 'S12', 'ccd24': 'S13', 'ccd25': 'S1',
+              'ccd26': 'S2', 'ccd27': 'S3', 'ccd28': 'S4', 'ccd29': 'S5', 'ccd30': 'S6',
+              'ccd31': 'S7', 'ccd32': 'N1', 'ccd33': 'N2', 'ccd34': 'N3', 'ccd35': 'N4',
+              'ccd36': 'N5', 'ccd37': 'N6', 'ccd38': 'N7', 'ccd39': 'N8', 'ccd40': 'N9',
+              'ccd41': 'N10', 'ccd42': 'N11', 'ccd43': 'N12', 'ccd44': 'N13', 'ccd45': 'N14',
+              'ccd46': 'N15', 'ccd47': 'N16', 'ccd48': 'N17', 'ccd49': 'N18', 'ccd50': 'N19',
+              'ccd51': 'N20', 'ccd52': 'N21', 'ccd53': 'N22', 'ccd54': 'N23', 'ccd55': 'N24',
+              'ccd56': 'N25', 'ccd57': 'N26', 'ccd58': 'N27', 'ccd59': 'N28', 'ccd60': 'N29',
+              'ccd61': 'N30', 'ccd62': 'N31',
+              }
+
+    outDict = dict()
+    with open(fromFile) as f:
+        for line in f:
+            li = line.strip()
+            if not li.startswith('#'):
+                elem = li.split()
+
+                victimDetAmp = elem[0]
+                sourceDetAmp = elem[1]
+                coeff = float(elem[2])
+
+                if 'A' in victimDetAmp:
+                    victimAmp = 'A'
+                elif 'B' in victimDetAmp:
+                    victimAmp = 'B'
+                else:
+                    raise RuntimeError(f"Unknown amp: {victimDetAmp}")
+
+                if 'A' in sourceDetAmp:
+                    sourceAmp = 'A'
+                elif 'B' in sourceDetAmp:
+                    sourceAmp = 'B'
+                else:
+                    raise RuntimeError(f"Unknown amp: {sourceDetAmp}")
+
+                victimDet = victimDetAmp.replace(victimAmp, "")
+                sourceDet = sourceDetAmp.replace(sourceAmp, "")
+                victimDet = detMap[victimDet]
+                sourceDet = detMap[sourceDet]
+
+                victimAmp = ampIndexMap[victimAmp]
+                sourceAmp = ampIndexMap[sourceAmp]
+
+                if victimDet not in outDict:
+                    outDict[victimDet] = dict()
+                    outDict[victimDet]['metadata'] = PropertyList()
+                    outDict[victimDet]['metadata']['OBSTYPE'] = 'CROSSTALK'
+                    outDict[victimDet]['interChip'] = dict()
+                    outDict[victimDet]['crosstalkShape'] = (2, 2)
+                    outDict[victimDet]['hasCrosstalk'] = True
+                    outDict[victimDet]['nAmp'] = 2
+
+                if sourceDet == victimDet:
+                    outDict[victimDet]['metadata']['DETECTOR'] = victimDet
+                    outDict[victimDet]['metadata']['DETECTOR_SERIAL'] = "UNKNOWN"
+                    outDict[victimDet]['DETECTOR'] = victimDet
+                    outDict[victimDet]['DETECTOR_SERIAL'] = "UNKNOWN"
+
+                    if 'coeffs' not in outDict[victimDet]:
+                        # shape=outDict[victimDet]['crosstalkShape'])
+                        outDict[victimDet]['coeffs'] = np.zeros_like([], shape=(2, 2))
+
+                    outDict[victimDet]['coeffs'][victimAmp][sourceAmp] = coeff
+                else:
+                    if sourceDet not in outDict[victimDet]['interChip']:
+                        # shape=outDict[victimDet]['crosstalkShape'])
+                        outDict[victimDet]['interChip'][sourceDet] = np.zeros_like([], shape=(2, 2))
+
+                    outDict[victimDet]['interChip'][sourceDet][victimAmp][sourceAmp] = coeff
+
+    return outDict
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert a DECam crosstalk file into LSST CrosstalkCalibs.")
+    parser.add_argument(dest="fromFile", help="DECam crosstalk file.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Print data about each detector.")
+    parser.add_argument("-f", "--force", action="store_true", help="Overwrite existing CrosstalkCalibs.")
+    cmd = parser.parse_args()
+
+    outDict = readFile(fromFile=cmd.fromFile)
+
+    crosstalkDir = "./crosstalk/"
+    if os.path.exists(crosstalkDir):
+        if not cmd.force:
+            print("Output directory %r exists; use --force to replace" % (crosstalkDir, ))
+            sys.exit(1)
+        print("Replacing data in crosstalk directory %r" % (crosstalkDir, ))
+    else:
+        print("Creating crosstalk directory %r" % (crosstalkDir, ))
+        os.makedirs(crosstalkDir)
+
+    for detName in outDict:
+        if cmd.verbose:
+            print(f"{detName}: has crosstalk? {outDict[detName]['hasCrosstalk']}")
+            print(f"COEFF:\n{outDict[detName]['coeffs']}")
+            for source in outDict[detName]['interChip']:
+                print(f"INTERCHIP {source}:\n{outDict[detName]['interChip'][source]}")
+        makeDetectorCrosstalk(dataDict=outDict[detName])

--- a/pipelines/RunIsr.yaml
+++ b/pipelines/RunIsr.yaml
@@ -1,0 +1,10 @@
+description: ip_isr handling of DECam-specific inter-chip crosstalk.  See DM-25348.
+instrument: lsst.obs.decam.DarkEnergyCamera
+tasks:
+  isrOscan:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'postISRCCD'
+      doLinearize: False
+      doCrosstalk: True

--- a/policy/DecamMapper.yaml
+++ b/policy/DecamMapper.yaml
@@ -183,6 +183,23 @@ calibrations:
     validStartName: validStart
     validEndName: validEnd
     validRange: true
+  crosstalk:
+    columns:
+    - date
+    - ccdnum
+    level: ccd
+    obsTimeName: date
+    persistable: BaseCatalog
+    python: lsst.ip.isr.CrosstalkCalib
+    refCols:
+    - visit
+    reference: raw_visit
+    storage: FitsStorage
+    tables: crosstalk
+    template: crosstalk/%(calibDate)s/crosstalk-%(calibDate)s-%(ccdnum)03d.fits
+    validStartName: validStart
+    validEndName: validEnd
+    validRange: true
   illumcor:
     columns:
     - filter

--- a/python/lsst/obs/decam/crosstalk.py
+++ b/python/lsst/obs/decam/crosstalk.py
@@ -146,10 +146,10 @@ class DecamCrosstalkTask(CrosstalkTask):
             try:
                 source_exposure = butler.get('raw', dataId={'visit': visit, 'ccd': sourceDet})
             except RuntimeError:
-                self.log.warn('Cannot access source %s, SKIPPING IT' % sourceDet)
+                self.log.warn(f"Cannot access source {sourceDet}, SKIPPING IT")
             else:
-                self.log.info('Correcting victim %s from crosstalk source %s' %
-                              (crosstalk._detectorName, sourceDet))
+                self.log.info(f"Correcting victim {crosstalk._detectorName} "
+                              f"from crosstalk source {sourceDet}.")
 
                 for amp in source_exposure.getDetector():
                     decamisr.overscanCorrection(source_exposure, amp)

--- a/python/lsst/obs/decam/decamMapper.py
+++ b/python/lsst/obs/decam/decamMapper.py
@@ -376,19 +376,3 @@ class DecamMapper(CameraMapper):
         packageName = cls.getPackageName()
         packageDir = getPackageDir(packageName)
         return os.path.join(packageDir, "decam", "crosstalk")
-
-    def map_crosstalk(self, dataId, write=False):
-        """Map a crosstalk table.
-        """
-        actualId = self._transformId(dataId)
-        detName = self._extractDetectorName(dataId)
-        location = "%s.fits" % (detName)
-        return ButlerLocation(
-            pythonType="lsst.ip.isr.CrosstalkCalib",
-            cppType="Config",
-            storageName="FitsStorage",
-            locationList=[location],
-            dataId=actualId,
-            mapper=self,
-            storage=Storage.makeFromURI(self.getCrosstalkDir())
-        )

--- a/python/lsst/obs/decam/decamMapper.py
+++ b/python/lsst/obs/decam/decamMapper.py
@@ -368,3 +368,27 @@ class DecamMapper(CameraMapper):
             mapper=self,
             storage=Storage.makeFromURI(self.getLinearizerDir())
         )
+
+    @classmethod
+    def getCrosstalkDir(cls):
+        """Directory containing crosstalk tables.
+        """
+        packageName = cls.getPackageName()
+        packageDir = getPackageDir(packageName)
+        return os.path.join(packageDir, "decam", "crosstalk")
+
+    def map_crosstalk(self, dataId, write=False):
+        """Map a crosstalk table.
+        """
+        actualId = self._transformId(dataId)
+        detName = self._extractDetectorName(dataId)
+        location = "%s.fits" % (detName)
+        return ButlerLocation(
+            pythonType="lsst.ip.isr.CrosstalkCalib",
+            cppType="Config",
+            storageName="FitsStorage",
+            locationList=[location],
+            dataId=actualId,
+            mapper=self,
+            storage=Storage.makeFromURI(self.getCrosstalkDir())
+        )


### PR DESCRIPTION
Handle crosstalk via a CrosstalkCalibs persisted as FITS/YAML.  Use ip_isr's updated CrosstalkTask for application, even for inter-ccd crosstalk.  obs_decam still needs to subclass CrosstalkTask to implement the prepCrosstalk() method with gen2 butlers.