### PR TITLE
DM-25407: ap_verify cannot handle curated crosstalk data in Gen 2

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -6,10 +6,12 @@ from lsst.obs.decam.ingest import DecamIngestTask
 
 decamConfigDir = os.path.dirname(__file__)
 
-config.textDefectPath = os.path.join(getPackageDir('obs_decam_data'), 'decam', 'defects')
+# Can't refer to os.path.join inside list comprehension
+config.curatedCalibPaths = []
+for calibType in {'defects', 'crosstalk'}:
+    config.curatedCalibPaths.append(os.path.join(getPackageDir('obs_decam_data'), 'decam', calibType))
 config.dataIngester.retarget(DecamIngestTask)
 config.dataIngester.load(os.path.join(decamConfigDir, 'ingest.py'))
 config.calibIngester.load(os.path.join(decamConfigDir, 'ingestCalibs.py'))
-config.defectIngester.load(os.path.join(decamConfigDir, 'ingestCuratedCalibs.py'))
-config.defectIngester.parse.extnames = []
-
+config.curatedCalibIngester.load(os.path.join(decamConfigDir, 'ingestCuratedCalibs.py'))
+config.curatedCalibIngester.parse.extnames = []


### PR DESCRIPTION
This PR edits `datasetIngest.py` for the changes made to `DatasetIngestConfig` in lsst/ap_verify#91, and adds crosstalk coefficients to the list of data products to be ingested.