### PR TITLE
Tickets/DM-26554: Use decam ISR configs for bias and flat construction

### DIFF
--- a/config/bias.py
+++ b/config/bias.py
@@ -1,2 +1,10 @@
+import os.path
+
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))
+config.isr.doBias = False
+config.isr.doFlat = False
+config.isr.doDark = False
+config.isr.doFringe = False
+
 config.dateObs = "date"
 config.ccdKeys = ["ccdnum"]

--- a/config/dark.py
+++ b/config/dark.py
@@ -1,2 +1,9 @@
+import os.path
+
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))
+config.isr.doFlat = False
+config.isr.doDark = False
+config.isr.doFringe = False
+
 config.dateObs = "date"
 config.ccdKeys = ["ccdnum"]

--- a/config/flat.py
+++ b/config/flat.py
@@ -1,2 +1,8 @@
+import os.path
+
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))
+config.isr.doFlat = False
+config.isr.doFringe = False
+
 config.dateObs = "date"
 config.ccdKeys = ["ccdnum"]

--- a/config/fringe.py
+++ b/config/fringe.py
@@ -1,2 +1,7 @@
+import os.path
+
+config.isr.load(os.path.join(os.path.dirname(__file__), "isr.py"))
+config.isr.doFringe = False
+
 config.dateObs = "date"
 config.ccdKeys = ["ccdnum"]


### PR DESCRIPTION
The config settings set in `config/isr.py` were used correctly in `processCcd.py`, but were not used for `constructBias.py` or `constructFlat.py`. This was not a problem for processing that used the Decam community pipeline calibrations, but resulted in the incorrect processing of the master bias in particular.

The defaults in `config/isr.py` also turn on and apply settings that are incorrect for constructing the master bias or flat, so I explicitly disabled these in a separate commit.