### PR TITLE
DM-27168: Phase out use of FilterProperty

### DIFF
--- a/tests/test_getInstcal.py
+++ b/tests/test_getInstcal.py
@@ -61,7 +61,7 @@ class GetInstcalTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(exp.getWidth(), self.size[0])
         self.assertEqual(exp.getHeight(), self.size[1])
         self.assertEqual(exp.getDetector().getId(), self.dataId["ccdnum"])
-        self.assertEqual(exp.getFilter().getFilterProperty().getName(), self.filter)
+        self.assertEqual(exp.getFilter().getCanonicalName(), self.filter)
         self.assertTrue(exp.hasWcs())
         magZero = 2.5 * math.log10(exp.getPhotoCalib().getInstFluxAtZeroMagnitude())
         self.assertAlmostEqual(magZero, 28.957)

--- a/tests/test_getRaw.py
+++ b/tests/test_getRaw.py
@@ -93,7 +93,7 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(exp.getWidth(), self.size[0])
         self.assertEqual(exp.getHeight(), self.size[1])
         self.assertEqual(exp.getDetector().getId(), self.dataId["ccdnum"])
-        self.assertEqual(exp.getFilter().getFilterProperty().getName(), self.filter)
+        self.assertEqual(exp.getFilter().getCanonicalName(), self.filter)
         self.assertTrue(exp.hasWcs())
 
         # Metadata which should have been copied from zeroth extension.
@@ -142,7 +142,7 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         print("detector id: %s" % exp.getDetector().getId())
         print("filter: %s" % self.filter)
         self.assertEqual(exp.getDetector().getId(), self.dataId["ccdnum"])
-        self.assertEqual(exp.getFilter().getFilterProperty().getName(), self.filter)
+        self.assertEqual(exp.getFilter().getCanonicalName(), self.filter)
         self.assertTrue(exp.hasWcs())
 
     def testFringe(self):
@@ -152,7 +152,7 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         print("detector id: %s" % exp.getDetector().getId())
         print("filter: %s" % self.filter)
         self.assertEqual(exp.getDetector().getId(), self.dataId["ccdnum"])
-        self.assertEqual(exp.getFilter().getFilterProperty().getName(), self.filter)
+        self.assertEqual(exp.getFilter().getCanonicalName(), self.filter)
 
     def testDefect(self):
         """Test retrieval of defect list"""


### PR DESCRIPTION
End usage of FilterProperty, as per RFC-730.