### PR TITLE
DM-23985: Cannot do linearity corrections in Gen 3 DECam processing

### DIFF
--- a/config/ingestCuratedCalibs.py
+++ b/config/ingestCuratedCalibs.py
@@ -8,7 +8,7 @@ config.register.columns = {'filter': 'text',
                            'validStart': 'text',
                            'validEnd': 'text',
                            }
-config.register.tables = ['defects', 'crosstalk']
+config.register.tables = ['defects', 'crosstalk', 'linearity']
 config.register.detector = ['filter', 'ccdnum']
 config.register.unique = ['filter', 'ccdnum', 'calibDate']
 config.register.visit = ['calibDate']

--- a/decam/makeLinearizer.py
+++ b/decam/makeLinearizer.py
@@ -73,9 +73,9 @@ def makeLinearizerDecam(fromFile, force=False, verbose=False):
             myLinearity.fitParams[ampName] = np.array([])
             myLinearity.fitParamsErr[ampName] = np.array([])
             myLinearity.fitChiSq[ampName] = np.nan
+        calibDate = '1970-01-01T00:00:00'
         myLinearity.updateMetadata(camera=camera, detector=detector,
-                                   CALIBDATE='1970-01-01T00:00:00',
-                                   setCalibId=True)
+                                   CALIBDATE=calibDate, setCalibId=True)
         myLinearity.hasLinearity = True
 
         outDir = os.path.join(getPackageDir('obs_decam'), 'decam', 'CALIB', 'linearity',
@@ -86,7 +86,7 @@ def makeLinearizerDecam(fromFile, force=False, verbose=False):
         else:
             os.makedirs(outDir)
 
-        filename = "1970-01-01T00:00:00.yaml"
+        filename = calibDate + ".yaml"
         myLinearity.writeText(os.path.join(outDir, filename))
 
     print("Wrote %s linearizers" % (ccdind+1,))

--- a/decam/makeLinearizer.py
+++ b/decam/makeLinearizer.py
@@ -17,16 +17,40 @@ from lsst.utils import getPackageDir
 def makeLinearizerDecam(fromFile, force=False, verbose=False):
     """Convert the specified DECam linearity FITS table to standard LSST format
 
-    Details:
-    - Input format is one table per CCD, HDU is amplifier number,
-        the table has 3 columns: ADU, ADU_LINEAR_A, ADU_LINEAR_B.
-        The values of ADU contiguous (0, 1, 2...) but check and error out if not.
-        The values of the latter two are replacements (0+delta0, 1+delta1, 2+delta2...)
-        and this is converted to offsets for the LSST linearization tables (delta0, delta1, delta2...)
-    - Output is a set of LinearizeLookupTable instances, one per CCD, saved as dataset type "linearizer"
-    - The row indices for the linearization lookup table are (row index=amp name): 0=A, 1=B
+    Parameters
+    ----------
+    fromFile : `str`
+        Filename to read linearity data from.
+    force : `bool`, optional
+        Overwrite existing outputs?
+    verbose : `bool`, optional
+        Control message verbosity.
 
-    @param[in] fromFile  path to DECam linearity table (a FITS file with one HDU per amplifier)
+    Raises
+    ------
+    RuntimeError :
+        Raised if the ADU values are not contiguous.
+
+    Notes
+    -----
+
+    This script generates LSST linearity stand-alone LookupTables, as
+    well as middleware gen-3 `ip_isr` Linearizers.  These products are
+    written to ``DecamMapper.getLinearizerDir()`` for gen2 products,
+    and to ${OBS_DECAM_DIR}/decam/calib/linearizer/ for gen3 products.
+
+    The input file format is one table per CCD, with the HDU indexed
+    by amplifier number.  Each table has 3 columns: ADU, ADU_LINEAR_A,
+    ADU_LINEAR_B, and the values of ADU are contiguous (0, 1, 2...).
+    The values of the last two columns are replacements (0+delta0,
+    1+delta1, 2+delta2...) for each of the two amplifiers, and this is
+    converted to offsets for the LSST linearization tables (delta0,
+    delta1, delta2...).  Output is a set of LinearizeLookupTable
+    instances, one per CCD, saved as dataset type "linearizer" - The
+    row indices for the linearization lookup table are (row index=amp
+    name): 0=A, 1=B.  These linearization lookup tables are also
+    stored in the gen3 Linearizers, as are the appropriate row indices
+    and column offsets.
     """
     print("Making DECam linearizers from %r" % (fromFile,))
     butler = Butler(mapper=DecamMapper)


### PR DESCRIPTION
Create gen3 linearizers.

This involves wrapping the gen2 table data in the calibration class.