### PR TITLE
DM-27833: Enable gen3 inter-chip crosstalk for DECam

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -4,3 +4,12 @@ imports:
   - location: $PIPE_TASKS_DIR/pipelines/DRP.yaml
     exclude:
       - sourceTable
+      - isr
+  - location: $OBS_DECAM_DIR/pipelines/RunIsrWithCrosstalk.yaml
+# This DRP pipeline uses an obs_decam specific ISR configuration that
+# requires crosstalk sources to be pre-generated via the
+# RunIsrForCrosstalkSources.yaml pipeline.  This applies overscan
+# correction and writes a new dataset that is then used as needed for
+# the inter-chip crosstalk solutions.  Unless a specific overscan
+# change is required, it may be best to generate these crosstalk
+# sources soon after ingest to allow them to be readily available.

--- a/pipelines/RunIsr.yaml
+++ b/pipelines/RunIsr.yaml
@@ -1,4 +1,4 @@
-description: ip_isr handling of DECam-specific inter-chip crosstalk.  See DM-25348.
+description: Run IsrTask for DECam with only intra-chip crosstalk.  Inter-chip crosstalk needs pre-prepared crosstalkSources.
 instrument: lsst.obs.decam.DarkEnergyCamera
 tasks:
   isrOscan:

--- a/pipelines/RunIsrForCrosstalkSources.yaml
+++ b/pipelines/RunIsrForCrosstalkSources.yaml
@@ -1,0 +1,22 @@
+description: Prepare overscanSources (for ISR/interchip crosstalk).
+instrument: lsst.obs.decam.DarkEnergyCamera
+tasks:
+  overscan:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'oscanRaw'
+      doBias: False
+      doOverscan: True
+      doAssembleCcd: False
+      doVariance: False
+      doLinearize: False
+      doCrosstalk: False
+      doDefect: False
+      doNanMasking: False
+      doInterpolate: False
+      doBrighterFatter: False
+      doDark: False
+      doFlat: False
+      doApplyGains: False
+      doFringe: False

--- a/pipelines/RunIsrForCrosstalkSources.yaml
+++ b/pipelines/RunIsrForCrosstalkSources.yaml
@@ -1,11 +1,11 @@
-description: Prepare overscanSources (for ISR/interchip crosstalk).
+description: Prepare crosstalkSources for ISR/interchip crosstalk by running overscan correction on raw frames.
 instrument: lsst.obs.decam.DarkEnergyCamera
 tasks:
   overscan:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
       connections.ccdExposure: 'raw'
-      connections.outputExposure: 'oscanRaw'
+      connections.outputExposure: 'overscanRaw'
       doBias: False
       doOverscan: True
       doAssembleCcd: False

--- a/pipelines/RunIsrWithCrosstalk.yaml
+++ b/pipelines/RunIsrWithCrosstalk.yaml
@@ -1,0 +1,11 @@
+description: Run ISR using crosstalkSources for interchip crosstalk.
+instrument: lsst.obs.decam.DarkEnergyCamera
+tasks:
+  isr:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'postISRCCD'
+      connections.crosstalkSources: 'oscanRaw'
+      doOverscan: True
+      doCrosstalk: True

--- a/pipelines/RunIsrWithCrosstalk.yaml
+++ b/pipelines/RunIsrWithCrosstalk.yaml
@@ -1,4 +1,4 @@
-description: Run ISR using crosstalkSources for interchip crosstalk.
+description: Run ISR using pregenerated crosstalkSources for interchip crosstalk.
 instrument: lsst.obs.decam.DarkEnergyCamera
 tasks:
   isr:
@@ -6,6 +6,6 @@ tasks:
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'postISRCCD'
-      connections.crosstalkSources: 'oscanRaw'
+      connections.crosstalkSources: 'overscanRaw'
       doOverscan: True
       doCrosstalk: True


### PR DESCRIPTION
Add updated two-part crosstalk ISR pipeline definitions.