### PR TITLE
DM-29265: Create DECam override file for ap.verify.Gen3DatasetIngestTask

### DIFF
--- a/config/datasetIngest-gen3.py
+++ b/config/datasetIngest-gen3.py
@@ -1,0 +1,5 @@
+# Config override for lsst.ap.verify.Gen3DatasetIngestTask
+
+from lsst.obs.decam import DecamRawIngestTask
+
+config.ingester.retarget(DecamRawIngestTask)


### PR DESCRIPTION
This PR adds an automatic config override that uses `DecamRawIngestTask` when ingesting `ap_verify` datasets.