### PR TITLE
DM-28439: Converting HiTS2015 repo fails on bad filter

### DIFF
--- a/python/lsst/obs/decam/_instrument.py
+++ b/python/lsst/obs/decam/_instrument.py
@@ -113,9 +113,9 @@ class DarkEnergyCamera(Instrument):
         factory = TranslatorFactory()
         factory.addGenericInstrumentRules(self.getName(), calibFilterType="band",
                                           detectorKey="ccdnum")
-        # DECam calibRegistry entries are bands, but we need physical_filter
-        # in the gen3 registry.
-        factory.addRule(BandToPhysicalFilterKeyHandler(self.filterDefinitions),
+        # DECam calibRegistry entries are bands or aliases, but we need
+        # physical_filter in the gen3 registry.
+        factory.addRule(_DecamBandToPhysicalFilterKeyHandler(self.filterDefinitions),
                         instrument=self.getName(),
                         gen2keys=("filter",),
                         consume=("filter",),

--- a/python/lsst/obs/decam/_instrument.py
+++ b/python/lsst/obs/decam/_instrument.py
@@ -121,3 +121,28 @@ class DarkEnergyCamera(Instrument):
                         consume=("filter",),
                         datasetTypeName="cpFlat")
         return factory
+
+
+class _DecamBandToPhysicalFilterKeyHandler(BandToPhysicalFilterKeyHandler):
+    """A specialization of `~lsst.obs.base.gen2to3.BandToPhysicalKeyHandler`
+    that allows filter aliases to be used as alternative band names.
+
+    Parameters
+    ----------
+    filterDefinitions : `lsst.obs.base.FilterDefinitionCollection`
+        The filters to translate from Gen 2 to Gen 3.
+    """
+
+    __slots__ = ("_aliasMap",)
+
+    def __init__(self, filterDefinitions):
+        super().__init__(filterDefinitions)
+        self._aliasMap = {alias: d.physical_filter for d in filterDefinitions for alias in d.alias}
+
+    def extract(self, gen2id, *args, **kwargs):
+        # Expect _aliasMap to be small, so try it first
+        gen2Filter = gen2id["filter"]
+        if gen2Filter in self._aliasMap:
+            return self._aliasMap[gen2Filter]
+        else:
+            return super().extract(gen2id, *args, **kwargs)

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -48,6 +48,19 @@ class TestDarkEnergyCamera(InstrumentTests, lsst.utils.tests.TestCase):
         self.instrument = lsst.obs.decam.DarkEnergyCamera()
 
 
+class TestDecamTranslators(lsst.utils.tests.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.filters = lsst.obs.decam.DarkEnergyCamera().filterDefinitions
+
+    def testDecamBandToPhysicalFilter(self):
+        translator = lsst.obs.decam._instrument._DecamBandToPhysicalFilterKeyHandler(self.filters)
+        self.assertEqual(translator.extract({"filter": "g"}), "g DECam SDSS c0001 4720.0 1520.0")
+        self.assertEqual(translator.extract({"filter": "y"}), "Y DECam c0005 10095.0 1130.0")
+        self.assertEqual(translator.extract({"filter": "Y"}), "Y DECam c0005 10095.0 1130.0")
+        self.assertEqual(translator.extract({"filter": "fake"}), "fake")
+
+
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass
 


### PR DESCRIPTION
This PR adds filter alias handling to DECam's Gen 2 to Gen 3 conversion code. In particular, this allows both `y` and `Y` to be recognized as filter names.