### PR TITLE
DM-30015: Update Sphinx conf.py for documenteer 0.6

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,4 @@
 """Sphinx configuration file for an LSST stack package.
-
 This configuration only affects single-package Sphinx documentation builds.
 For more information, see:
 https://developer.lsst.io/stack/building-single-package-docs.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,13 @@ max-line-length = 110
 # TODO: remove E266 when Task documentation is converted to rst in DM-14207.
 ignore = E133, E226, E228, E266, N802, N803, N806, N812, N815, N816, W503
 exclude =
-    __init__.py
-    doc/conf.py
-    doc/_build/html/conf.py
-    config/*
-    tests/.tests/*
-    tests/config/*
+    bin,
+    doc/conf.py,
+    **/*/__init__.py,
+    **/*/version.py,
+    config/*,
+    tests/.tests,
+    tests/config/*,
     decam/camGeom/camera.py
 
 


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package)

- Add a basic README
- Update doc/conf.py for the documenteer 0.6 Sphinx configuration API
- Update flake8 exclusions in setup.cfg