### PR TITLE
Register the new N419 and N540 filters

### DIFF
--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -13,7 +13,10 @@ for refObjLoader in (config.astromRefObjLoader,
     # Note the u-band results may not be useful without a color term
     refObjLoader.filterMap['u'] = 'g'
     refObjLoader.filterMap['Y'] = 'y'
+    refObjLoader.filterMap['N419'] = 'g'
+    refObjLoader.filterMap['N540'] = 'g'
     refObjLoader.filterMap['N708'] = 'i'
+    refObjLoader.filterMap['N964'] = 'z'
 
 # This sets up the reference catalog for Gen3.
 config.connections.astromRefCat = "ps1_pv3_3pi_20170110"

--- a/config/characterizeImage.py
+++ b/config/characterizeImage.py
@@ -10,4 +10,7 @@ config.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
 # Note the u-band results may not be useful without a color term
 config.refObjLoader.filterMap['u'] = 'g'
 config.refObjLoader.filterMap['Y'] = 'y'
+config.refObjLoader.filterMap['N419'] = 'g'
+config.refObjLoader.filterMap['N540'] = 'g'
 config.refObjLoader.filterMap['N708'] = 'i'
+config.refObjLoader.filterMap['N964'] = 'z'

--- a/config/measureCoaddSources.py
+++ b/config/measureCoaddSources.py
@@ -1,5 +1,8 @@
 config.match.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
 config.match.refObjLoader.filterMap['u'] = 'g'
 config.match.refObjLoader.filterMap['Y'] = 'y'
+config.match.refObjLoader.filterMap['N419'] = 'g'
+config.match.refObjLoader.filterMap['N540'] = 'g'
 config.match.refObjLoader.filterMap['N708'] = 'i'
+config.match.refObjLoader.filterMap['N964'] = 'z'
 config.connections.refCat = "ps1_pv3_3pi_20170110"

--- a/python/lsst/obs/decam/decamFilters.py
+++ b/python/lsst/obs/decam/decamFilters.py
@@ -57,4 +57,10 @@ DECAM_FILTER_DEFINITIONS = FilterDefinitionCollection(
     FilterDefinition(physical_filter="N708 DECam c0012 7080.0 400.0",
                      band="N708",
                      lambdaEff=708),
+    FilterDefinition(physical_filter="N540 DECam c0014 5403.2 210.0",
+                     band="N540",
+                     lambdaEff=540),
+    FilterDefinition(physical_filter="N419 DECam c0013 4194.0 75.0",
+                     band="N419",
+                     lambdaEff=419),
 )


### PR DESCRIPTION

There are two new narrow-/medium-band filters installed to DECam: an `N419` narrow-band filter and an `N540` medium-band filter. The `N540` filter is used by the Merian survey, which depends on the LSSTPipe for data reduction.

- I added the `FilterDefinition` of both filters to `decamFilters.py`.
- I assigned the PS-1 g-band as the reference filter for both of them in `config/calibrate.py`, `config/characterizeImage.py`, and `config/measureCoaddSources.py`. 
- I noticed that the reference filter information for the `N964` filter that has been registered is missing, so I assign the z-band to it in the three files too.