### PR TITLE
DM-29955: Add ExposureInfo id getter

### DIFF
--- a/python/lsst/obs/decam/decamMapper.py
+++ b/python/lsst/obs/decam/decamMapper.py
@@ -226,6 +226,8 @@ class DecamMapper(CameraMapper):
         exp.setPhotoCalib(afwImage.makePhotoCalibFromCalibZeroPoint(10**(0.4 * md.getScalar("MAGZERO")), 0))
         visitInfo = self.makeRawVisitInfo(md=md)
         exp.getInfo().setVisitInfo(visitInfo)
+        if 'EXPID' in md:
+            exp.info.id = md['EXPID']
 
         for kw in ('LTV1', 'LTV2'):
             md.remove(kw)


### PR DESCRIPTION
This PR uses the `id` component added on lsst/afw#613.