### PR TITLE
DM-32315: Fix trying to set exposure ID for non-raws in Gen 2

### DIFF
--- a/python/lsst/obs/decam/decamMapper.py
+++ b/python/lsst/obs/decam/decamMapper.py
@@ -253,7 +253,7 @@ class DecamMapper(CameraMapper):
             The standardized Exposure.
         """
         return self._standardizeExposure(self.exposures['raw'], item, dataId,
-                                         trimmed=False)
+                                         trimmed=False, setExposureId=True)
 
     def _createInitialSkyWcs(self, exposure):
         # DECam has a coordinate system flipped on X with respect to our


### PR DESCRIPTION
This PR applies the changes made on lsst/obs_base#395 to DECam raws. There is no need to support instcals, which already had correct exposure IDs added on #204.