### PR TITLE
DM-34693: add instrument config for SkyBotEphemerisQueryTask

### DIFF
--- a/config/SkyBotEphemerisQuery.py
+++ b/config/SkyBotEphemerisQuery.py
@@ -1,0 +1,4 @@
+# DECam-specific config for lsst.ap.association.skyBotEphemerisQuery.SkyBotEphemerisQueryTask
+
+config.observerCode = "W84"        # IAU code for DECam
+config.queryRadiusDegrees = 1.3    # DECam FoV radius + 20% margin


### PR DESCRIPTION
This PR adds an instrument-level config override file for `lsst.ap.association.skyBotEphemerisQuery.SkyBotEphemerisQueryTask`. I'm fairly confident that these values are appropriate for all DECam data sets and for all pipelines.