### PR TITLE
DM-33429: Add ability to do both serial and parallel overscan correction

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -25,13 +25,6 @@ config.doOverscan = True
 config.overscan.fitType = "MEDIAN_PER_ROW"
 config.overscan.order = 1
 config.overscan.numSigmaClip = 3.0
-config.overscanNumLeadingColumnsToSkip = 0
-config.overscanNumTrailingColumnsToSkip = 0
-config.overscanMaxDev = 1000.0
-config.overscanBiasJump = True
-config.overscanBiasJumpKeyword = "FPA"
-config.overscanBiasJumpDevices = ["DECAM_BKP3", "DECAM_BKP5", "DECAM_BKP1", "DECAM_BKP4"]
-config.overscanBiasJumpLocation = 2098
 
 config.doAssembleCcd = True
 # Use default ISR assembleCcdTask

--- a/tests/config/isr.py
+++ b/tests/config/isr.py
@@ -25,13 +25,9 @@ config.doOverscan = True
 config.overscan.fitType = "MEDIAN_PER_ROW"
 config.overscan.order = 1
 config.overscan.numSigmaClip = 3.0
-config.overscanNumLeadingColumnsToSkip = 0
-config.overscanNumTrailingColumnsToSkip = 0
-config.overscanMaxDev = 1000.0
-config.overscanBiasJump = True
-config.overscanBiasJumpKeyword = "FPA"
-config.overscanBiasJumpDevices = ["DECAM_BKP3", "DECAM_BKP5", "DECAM_BKP1", "DECAM_BKP4"]
-config.overscanBiasJumpLocation = 2098
+config.overscan.leadingColumnsToSkip = 0
+config.overscan.trailingColumnsToSkip = 0
+config.overscan.maxDeviation = 1000.0
 
 config.doAssembleCcd = True
 # Use default ISR assembleCcdTask


### PR DESCRIPTION
Switch config file to use current overscan config options instead of deprecated isrTask config options.