### PR TITLE
DM-32940: Remove unnecessary test for butler dataset existence

### DIFF
--- a/tests/test_isr.py
+++ b/tests/test_isr.py
@@ -141,7 +141,6 @@ class DecamIsrTestCase(lsst.utils.tests.TestCase):
         """Test basic ISR."""
         butler = lsst.daf.butler.Butler(self.repo, instrument='DECam', collections=self.basic_collection)
 
-        self.assertTrue(butler.datasetExists('postISRCCD', exposure=EXPOSURE, detector=DETECTOR))
         exp = butler.get('postISRCCD', exposure=EXPOSURE, detector=DETECTOR)
         self.assertIsInstance(exp, lsst.afw.image.ExposureF)
 


### PR DESCRIPTION
Requires lsst/daf_butler#840