### PR TITLE
DM-35579: Remove pipelines forwarding stubs.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,4 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConstruct("obs_decam", disableCc=True, subDirList=['config', 'doc', 'pipelines', 'python', 'ups',
-                                                                 'decam'])
+
+scripts.BasicSConstruct("obs_decam", disableCc=True, subDirList=["config", "doc", "python", "ups", "decam"])

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -1,4 +1,0 @@
-description: >
-  This pipeline is a backwards-compatibility stub.
-imports:
-  location: $DRP_PIPE_DIR/ingredients/DECam/DRP.yaml

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,7 +1,0 @@
-# Temporary DECam Pipelines
-
-DECam-specific pipelines here are backwards-compatibility stubs only.
-
-As RFC-775 is fully implemented, it is anticipated this `pipelines` directory
-will go away. Please put new pipelines in `*_pipe` or some other appropriate
-non-obs-package location.


### PR DESCRIPTION
Pipelines should go in *_pipe packages.