### PR TITLE
DM-34340: Convert deprecated dimension packer usage.

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -125,7 +125,8 @@ class DecamIngestFullFileTestCase(DecamTestBase, lsst.utils.tests.TestCase):
         # results consistent with what we have historically gotten (from Gen2).
         for dataId in self.dataIds:
             expandedDataId = butler.registry.expandDataId(dataId)
-            packed, bits = expandedDataId.pack("exposure_detector", returnMaxBits=True)
+            packer = self.instrumentClass.make_default_dimension_packer(expandedDataId, is_exposure=True)
+            packed, bits = packer.pack(expandedDataId, returnMaxBits=True)
             self.assertEqual(packed, int(f"{dataId['exposure']}{dataId['detector']:02}"))
             self.assertEqual(bits, 32)
 


### PR DESCRIPTION
This should have happened long ago, on DM-31924.  I found it here by accidentally being overzealous about which deprecation warnings I temporarily turned into errors in daf_butler.