### PR TITLE
DM-40441: Drop unnecessary argument to SimplePipelineExecutor.from_pipeline.

### DIFF
--- a/tests/test_isr.py
+++ b/tests/test_isr.py
@@ -85,7 +85,6 @@ tasks:
     executor = SimplePipelineExecutor.from_pipeline(
         pipeline,
         where=f"exposure={EXPOSURE} and detector={DETECTOR}",
-        root=repo,
         butler=butler
     )
 


### PR DESCRIPTION
The 'root' argument never existed, but until DM-40441 this method seems to have accidentally accepted (and ignored) arbitrary kwargs.