### PR TITLE
DM-42576: mpSkyEphemerisQuery config overrides

### DIFF
--- a/config/mpSkyEphemerisQuery.py
+++ b/config/mpSkyEphemerisQuery.py
@@ -1,0 +1,1 @@
+config.observerCode = "W84"  # IAU code for DECam


### PR DESCRIPTION
Just adding mpSkyEphemerisQuery overrides: observatory code W84 and a buffer of 0.2 degrees for the search cone. 